### PR TITLE
chore: barbell favicon — burnt orange on forest green

### DIFF
--- a/app/icon.svg
+++ b/app/icon.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <!-- Deep forest green background, rounded like a modern app icon -->
+  <rect width="32" height="32" rx="7.5" fill="#0F1A14"/>
+
+  <!-- Subtle inner shadow layer for depth -->
+  <rect width="32" height="32" rx="7.5" fill="url(#vignette)" opacity="0.25"/>
+
+  <defs>
+    <!-- Radial vignette for subtle depth -->
+    <radialGradient id="vignette" cx="50%" cy="50%" r="50%">
+      <stop offset="60%" stop-color="#0F1A14" stop-opacity="0"/>
+      <stop offset="100%" stop-color="#000" stop-opacity="1"/>
+    </radialGradient>
+
+    <!-- Plate gradient: bright top, darker base — gives a forged metal feel -->
+    <linearGradient id="plate-grad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#E06025"/>
+      <stop offset="50%" stop-color="#C84B1A"/>
+      <stop offset="100%" stop-color="#7A2D0D"/>
+    </linearGradient>
+
+    <!-- Bar gradient: subtler, recedes behind the plates -->
+    <linearGradient id="bar-grad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#A83C14"/>
+      <stop offset="100%" stop-color="#5A1E08"/>
+    </linearGradient>
+
+    <!-- Plate highlight: tiny bright strip at top edge -->
+    <linearGradient id="highlight" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#fff" stop-opacity="0.18"/>
+      <stop offset="30%" stop-color="#fff" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+
+  <!-- ── Bar (behind the plates in z-order) ── -->
+  <rect x="10.5" y="13.5" width="11" height="5" rx="1.5" fill="url(#bar-grad)"/>
+
+  <!-- ── Left weight plate ── -->
+  <rect x="3" y="8" width="7.5" height="16" rx="2.5" fill="url(#plate-grad)"/>
+  <!-- Left plate highlight -->
+  <rect x="3" y="8" width="7.5" height="6" rx="2.5" fill="url(#highlight)"/>
+
+  <!-- ── Right weight plate ── -->
+  <rect x="21.5" y="8" width="7.5" height="16" rx="2.5" fill="url(#plate-grad)"/>
+  <!-- Right plate highlight -->
+  <rect x="21.5" y="8" width="7.5" height="6" rx="2.5" fill="url(#highlight)"/>
+</svg>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,6 +25,14 @@ export const metadata: Metadata = {
     "A structured fitness coaching platform for coaches and individuals. Program, track, and progress with purpose.",
   keywords: ["fitness", "coaching", "strength training", "workout tracker"],
   metadataBase: new URL(APP_URL),
+  icons: {
+    icon: [
+      { url: "/icon.svg", type: "image/svg+xml", sizes: "any" },
+    ],
+    apple: [
+      { url: "/icon.svg", type: "image/svg+xml" },
+    ],
+  },
   openGraph: {
     title: "BuildBase — Structured Fitness Coaching",
     description:


### PR DESCRIPTION
## Favicon

Adds a custom SVG favicon designed to be immediately spottable in a crowded browser tab.

**Design rationale:**
- **Shape**: Barbell (two weight plates + connecting bar) — instantly communicates fitness, reads clearly at 16×16
- **Color**: Burnt orange `#C84B1A` plates on deep forest green `#0F1A14` background — this specific color pair is rare across browser tabs, which means the eye finds it fast even when buried among 20+ open tabs
- **Depth**: Plate gradient (bright top → dark base) and a subtle highlight stripe give a forged/metallic feel without adding visual noise at small sizes
- **Background**: Rounded rect with a dark vignette matches the modern app-icon convention (iOS/macOS aesthetic)

**Implementation:**
- `app/icon.svg` — Next.js App Router auto-discovers this and injects `<link rel="icon" href="/icon.svg" type="image/svg+xml">` into `<head>`. SVG scales perfectly from 16×16 tab to 180×180 apple-touch.
- `app/layout.tsx` — explicit `icons` field in Next.js `Metadata` as belt-and-suspenders.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)