### PR TITLE
feat: Batch 1.2 — role-based routing (RBAC) in proxy.ts

### DIFF
--- a/lib/rbac.ts
+++ b/lib/rbac.ts
@@ -1,0 +1,43 @@
+import type { UserRole } from "@/lib/types";
+
+/**
+ * Returns the minimum role required to access a given pathname, or null if
+ * no special role is needed (any authenticated user may proceed).
+ */
+export function getRequiredRole(pathname: string): UserRole | null {
+  if (
+    pathname.startsWith("/admin") ||
+    pathname.startsWith("/admin/")
+  ) {
+    return "admin";
+  }
+
+  if (
+    pathname.startsWith("/clients") ||
+    pathname.startsWith("/playbook")
+  ) {
+    return "coach";
+  }
+
+  return null;
+}
+
+/**
+ * Returns true if the given role is allowed to access a route that requires
+ * `requiredRole`.  Admins can access everything.
+ */
+export function canAccess(userRole: UserRole, requiredRole: UserRole): boolean {
+  if (userRole === "admin") return true;
+  if (requiredRole === "coach") return userRole === "coach";
+  return false;
+}
+
+/**
+ * Convenience: given a pathname and user role, returns true if the user is
+ * allowed to visit the route.
+ */
+export function isRouteAllowed(pathname: string, userRole: UserRole): boolean {
+  const required = getRequiredRole(pathname);
+  if (!required) return true;
+  return canAccess(userRole, required);
+}

--- a/lib/roadmap-data.ts
+++ b/lib/roadmap-data.ts
@@ -54,9 +54,10 @@ export const ROADMAP: RoadmapBatch[] = [
         id: "1-2",
         title: "Role-based routing + RLS policies",
         description: "proxy.ts guards per role, all tables have RLS policies enforcing admin/coach/user access.",
-        status: "not-started",
-        tests: false,
+        status: "in-progress",
+        tests: true,
         branch: "feat/batch-1-rbac",
+        pr: 8,
         scope: {
           owns: ["proxy.ts"],
           avoid: ["app/(auth)/", "scripts/"],

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createServerClient, type CookieOptions } from "@supabase/ssr";
 import { MONITOR_COOKIE, MONITOR_LOGIN_PATH } from "@/lib/constants";
+import { isRouteAllowed } from "@/lib/rbac";
+import type { UserRole } from "@/lib/types";
 
 export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
@@ -60,6 +62,27 @@ export async function proxy(request: NextRequest) {
 
   if (user && isAuthRoute) {
     return NextResponse.redirect(new URL("/dashboard", request.url));
+  }
+
+  // ── Role-based route protection ───────────────────────────────────────────
+  // Only query the DB when the route actually requires a specific role.
+  if (user) {
+    const isCoachRoute = pathname.startsWith("/clients") || pathname.startsWith("/playbook");
+    const isAdminRoute = pathname.startsWith("/admin");
+
+    if (isCoachRoute || isAdminRoute) {
+      const { data: profile } = await supabase
+        .from("profiles")
+        .select("role")
+        .eq("id", user.id)
+        .single();
+
+      const role = (profile?.role ?? "user") as UserRole;
+
+      if (!isRouteAllowed(pathname, role)) {
+        return NextResponse.redirect(new URL("/dashboard", request.url));
+      }
+    }
   }
 
   return response;

--- a/tests/rbac.test.ts
+++ b/tests/rbac.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import { getRequiredRole, canAccess, isRouteAllowed } from "@/lib/rbac";
+
+describe("getRequiredRole", () => {
+  it("returns null for /dashboard", () => {
+    expect(getRequiredRole("/dashboard")).toBeNull();
+  });
+
+  it("returns null for /sessions", () => {
+    expect(getRequiredRole("/sessions")).toBeNull();
+  });
+
+  it("returns null for /progress", () => {
+    expect(getRequiredRole("/progress")).toBeNull();
+  });
+
+  it("returns null for /coach-notes", () => {
+    expect(getRequiredRole("/coach-notes")).toBeNull();
+  });
+
+  it("returns 'coach' for /clients", () => {
+    expect(getRequiredRole("/clients")).toBe("coach");
+  });
+
+  it("returns 'coach' for /clients/some-id", () => {
+    expect(getRequiredRole("/clients/abc-123")).toBe("coach");
+  });
+
+  it("returns 'coach' for /playbook", () => {
+    expect(getRequiredRole("/playbook")).toBe("coach");
+  });
+
+  it("returns 'admin' for /admin", () => {
+    expect(getRequiredRole("/admin")).toBe("admin");
+  });
+
+  it("returns 'admin' for /admin/users", () => {
+    expect(getRequiredRole("/admin/users")).toBe("admin");
+  });
+
+  it("returns 'admin' for /admin/programs", () => {
+    expect(getRequiredRole("/admin/programs")).toBe("admin");
+  });
+});
+
+describe("canAccess", () => {
+  it("admin can access admin routes", () => {
+    expect(canAccess("admin", "admin")).toBe(true);
+  });
+
+  it("admin can access coach routes", () => {
+    expect(canAccess("admin", "coach")).toBe(true);
+  });
+
+  it("coach can access coach routes", () => {
+    expect(canAccess("coach", "coach")).toBe(true);
+  });
+
+  it("coach cannot access admin routes", () => {
+    expect(canAccess("coach", "admin")).toBe(false);
+  });
+
+  it("user cannot access coach routes", () => {
+    expect(canAccess("user", "coach")).toBe(false);
+  });
+
+  it("user cannot access admin routes", () => {
+    expect(canAccess("user", "admin")).toBe(false);
+  });
+});
+
+describe("isRouteAllowed", () => {
+  it("allows user on /dashboard", () => {
+    expect(isRouteAllowed("/dashboard", "user")).toBe(true);
+  });
+
+  it("allows user on /sessions", () => {
+    expect(isRouteAllowed("/sessions", "user")).toBe(true);
+  });
+
+  it("blocks user on /clients", () => {
+    expect(isRouteAllowed("/clients", "user")).toBe(false);
+  });
+
+  it("blocks user on /admin/users", () => {
+    expect(isRouteAllowed("/admin/users", "user")).toBe(false);
+  });
+
+  it("allows coach on /clients", () => {
+    expect(isRouteAllowed("/clients", "coach")).toBe(true);
+  });
+
+  it("allows coach on /playbook", () => {
+    expect(isRouteAllowed("/playbook", "coach")).toBe(true);
+  });
+
+  it("blocks coach on /admin/users", () => {
+    expect(isRouteAllowed("/admin/users", "coach")).toBe(false);
+  });
+
+  it("allows admin on /admin/users", () => {
+    expect(isRouteAllowed("/admin/users", "admin")).toBe(true);
+  });
+
+  it("allows admin on /clients", () => {
+    expect(isRouteAllowed("/clients", "admin")).toBe(true);
+  });
+
+  it("allows admin on /dashboard", () => {
+    expect(isRouteAllowed("/dashboard", "admin")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- `lib/rbac.ts` — pure helpers: `getRequiredRole(pathname)`, `canAccess(role, required)`, `isRouteAllowed(pathname, role)`
- `proxy.ts` — role guard block: only queries profiles DB when route actually needs a role check (coach/admin routes); redirects to `/dashboard` on role mismatch
- RLS policies already exist in `supabase/migrations/001_initial_schema.sql` — this PR wires the application-layer enforcement to match them
- `lib/roadmap-data.ts` — item 1-2 set to `in-progress`

## Role routing rules
| Route prefix | Required role |
|---|---|
| `/clients`, `/playbook` | `coach` or `admin` |
| `/admin/*` | `admin` only |
| Everything else | any authenticated user |

## Test plan
- [x] `pnpm test` — 73 tests pass (26 new rbac assertions)
- [x] `pnpm tsc --noEmit` — clean
- [ ] User visiting `/clients` → redirected to `/dashboard`
- [ ] Coach visiting `/admin/users` → redirected to `/dashboard`
- [ ] Admin visiting `/clients` → allowed through

> **Merge after:** PR #7 (batch-1-auth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)