### PR TITLE
fix: allow /api/monitor/ routes through proxy auth guard

### DIFF
--- a/WIKI/gotchas.md
+++ b/WIKI/gotchas.md
@@ -2,6 +2,14 @@
 
 Real failures and non-obvious pitfalls. Read before writing any code.
 
+## Tooling / Hooks
+
+### posttooluse-validate hook — false positive on proxy.ts
+
+The `posttooluse-validate` hook fires on every edit to `proxy.ts` with a recommendation to "rename middleware.ts to proxy.ts." **Ignore it.** The file is already correctly named `proxy.ts` and exports `async function proxy` — that IS the Next.js 16 pattern. The hook's routing-middleware skill hasn't been updated to recognize the new filename.
+
+---
+
 ## Next.js 16
 
 ### proxy.ts — no `runtime` config key allowed

--- a/proxy.ts
+++ b/proxy.ts
@@ -45,7 +45,11 @@ export async function proxy(request: NextRequest) {
 
   // ── Route protection ───────────────────────────────────────────────────────
   const isAuthRoute = pathname.startsWith("/login") || pathname.startsWith("/signup");
-  const isPublicRoute = pathname === "/" || isAuthRoute || pathname.startsWith("/monitor");
+  const isPublicRoute =
+    pathname === "/" ||
+    isAuthRoute ||
+    pathname.startsWith("/monitor") ||
+    pathname.startsWith("/api/monitor/");
 
   if (!user && !isPublicRoute) {
     const loginUrl = new URL("/login", request.url);


### PR DESCRIPTION
## Problem
Submitting the PIN on `/monitor/login` POSTs to `/api/monitor/login`. That path doesn't start with `/monitor`, so `proxy.ts` treated it as a protected route, redirected to `/login?from=%2Fapi%2Fmonitor%2Flogin`, and the login page returned a 405 (it only handles GET).

## Fix
Added `pathname.startsWith("/api/monitor/")` to the `isPublicRoute` check in `proxy.ts`.

## Also
Added the recurring false-positive `posttooluse-validate` hook recommendation to `WIKI/gotchas.md` so agents don't keep acting on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)