### PR TITLE
feat: Batch 1.2–1.4 — RBAC, profile shell, 12-week seed

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -1,11 +1,36 @@
-// TODO Batch 1: Protected layout — verify auth, redirect if no session
-// Will include Sidebar + Header components
-export default function AppLayout({ children }: { children: React.ReactNode }) {
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { Sidebar } from "@/components/layout/Sidebar";
+import { Header } from "@/components/layout/Header";
+
+export default async function AppLayout({ children }: { children: React.ReactNode }) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect("/login");
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("role, full_name, email, coach_id, onboarding_done")
+    .eq("id", user.id)
+    .single();
+
+  // Redirect to onboarding if first login (Batch 2 implements the wizard)
+  if (profile && !profile.onboarding_done) {
+    redirect("/onboarding");
+  }
+
+  const role = profile?.role ?? "user";
+  const fullName = profile?.full_name ?? profile?.email ?? "User";
+  const hasCoach = profile?.coach_id != null;
+
   return (
     <div style={{ minHeight: "100vh", background: "#0F1A14" }}>
-      {/* TODO: <Sidebar /> */}
+      <Sidebar role={role} hasCoach={hasCoach} />
       <div className="lg:ml-[220px] flex flex-col min-h-screen">
-        {/* TODO: <Header /> */}
+        <Header fullName={fullName} />
         <main className="flex-1 px-4 py-6">{children}</main>
       </div>
     </div>

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -1,0 +1,40 @@
+// TODO Batch 2: Onboarding wizard — collects full_name, gender, confirms template_tier.
+// Sets onboarding_done = true on completion. Until then, all app routes redirect here.
+export default function OnboardingPage() {
+  return (
+    <main
+      className="flex min-h-screen items-center justify-center px-4"
+      style={{ background: "#0F1A14" }}
+    >
+      <div
+        style={{
+          width: "100%",
+          maxWidth: 480,
+          background: "#1C2A20",
+          border: "1px solid #2A3D30",
+          borderRadius: 12,
+          padding: 40,
+          textAlign: "center",
+        }}
+      >
+        <h1
+          style={{
+            fontSize: 24,
+            fontWeight: 700,
+            color: "#E8F0E8",
+            fontFamily: "var(--font-display, sans-serif)",
+            marginBottom: 8,
+          }}
+        >
+          Welcome to{" "}
+          <span style={{ color: "#1C3A2A" }}>Build</span>
+          <span style={{ color: "#C84B1A", fontWeight: 700 }}>Base</span>
+        </h1>
+        <p style={{ color: "#8A9E8A", fontSize: 14, lineHeight: 1.6 }}>
+          Onboarding wizard coming in Batch 2. You&apos;ll set your name, gender, and training
+          tier here.
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -1,10 +1,13 @@
-// TODO Batch 1: Header component
-// - Mobile hamburger menu (opens Sidebar sheet)
-// - Page title (dynamic)
-// - User avatar + sign out dropdown
 "use client";
 
-export function Header() {
+import { LogOut } from "lucide-react";
+import { signOut } from "@/lib/actions/auth";
+
+interface HeaderProps {
+  fullName: string;
+}
+
+export function Header({ fullName }: HeaderProps) {
   return (
     <header
       style={{
@@ -23,15 +26,55 @@ export function Header() {
       {/* Mobile logo */}
       <span
         className="lg:hidden"
-        style={{ fontSize: 18, fontWeight: 700, fontFamily: "var(--font-space-grotesk, sans-serif)" }}
+        style={{
+          fontSize: 18,
+          fontWeight: 700,
+          fontFamily: "var(--font-display, sans-serif)",
+        }}
       >
         <span style={{ color: "#1C3A2A" }}>Build</span>
         <span style={{ color: "#C84B1A" }}>Base</span>
       </span>
 
-      {/* Right side placeholder */}
-      <div style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: 12 }}>
-        <div style={{ width: 32, height: 32, borderRadius: "50%", background: "#2A3D30" }} />
+      {/* Spacer for desktop (sidebar takes left side) */}
+      <div className="hidden lg:block" />
+
+      {/* Right: user name + sign out */}
+      <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+        <span
+          style={{
+            fontSize: 13,
+            color: "#8A9E8A",
+            maxWidth: 160,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {fullName}
+        </span>
+
+        <form action={signOut}>
+          <button
+            type="submit"
+            title="Sign out"
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              width: 32,
+              height: 32,
+              borderRadius: 8,
+              background: "transparent",
+              border: "1px solid #2A3D30",
+              color: "#8A9E8A",
+              cursor: "pointer",
+              transition: "border-color 0.15s, color 0.15s",
+            }}
+          >
+            <LogOut size={15} />
+          </button>
+        </form>
       </div>
     </header>
   );

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -1,11 +1,40 @@
-// TODO Batch 1: Sidebar component
-// - Role-aware navigation (user / coach / admin menu items)
-// - BuildBase logo/wordmark at top
-// - Active route highlighting
-// - Mobile: collapsible sheet
 "use client";
 
-export function Sidebar() {
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import {
+  LayoutDashboard,
+  Dumbbell,
+  TrendingUp,
+  MessageSquare,
+  Users,
+  BookOpen,
+  UserCog,
+  ClipboardList,
+} from "lucide-react";
+import { getNavItems, type NavItem } from "@/lib/profile";
+import type { UserRole } from "@/lib/types";
+
+const ICON_MAP: Record<string, React.ElementType> = {
+  LayoutDashboard,
+  Dumbbell,
+  TrendingUp,
+  MessageSquare,
+  Users,
+  BookOpen,
+  UserCog,
+  ClipboardList,
+};
+
+interface SidebarProps {
+  role: UserRole;
+  hasCoach: boolean;
+}
+
+export function Sidebar({ role, hasCoach }: SidebarProps) {
+  const pathname = usePathname();
+  const items = getNavItems(role, hasCoach);
+
   return (
     <aside
       style={{
@@ -24,39 +53,76 @@ export function Sidebar() {
       className="hidden lg:flex"
     >
       {/* Logo */}
-      <div style={{ padding: "0 20px 20px", borderBottom: "1px solid #2A3D30", marginBottom: 12 }}>
-        <span style={{ fontSize: 20, fontWeight: 700, fontFamily: "var(--font-space-grotesk, sans-serif)" }}>
-          <span style={{ color: "#1C3A2A" }}>Build</span>
-          <span style={{ color: "#C84B1A" }}>Base</span>
-        </span>
-      </div>
-
-      {/* Nav items — placeholder */}
-      <nav style={{ flex: 1, padding: "0 12px" }}>
-        {[
-          { label: "Dashboard",   href: "/dashboard" },
-          { label: "Sessions",    href: "/sessions" },
-          { label: "Progress",    href: "/progress" },
-          { label: "Coach's Notes", href: "/coach-notes" },
-        ].map((item) => (
-          <a
-            key={item.href}
-            href={item.href}
+      <div
+        style={{
+          padding: "0 20px 20px",
+          borderBottom: "1px solid #2A3D30",
+          marginBottom: 12,
+        }}
+      >
+        <Link href="/dashboard" style={{ textDecoration: "none" }}>
+          <span
             style={{
-              display: "block",
-              padding: "8px 12px",
-              borderRadius: 8,
-              color: "#8A9E8A",
-              textDecoration: "none",
-              fontSize: 14,
-              fontWeight: 500,
-              marginBottom: 2,
+              fontSize: 20,
+              fontWeight: 700,
+              fontFamily: "var(--font-display, sans-serif)",
             }}
           >
-            {item.label}
-          </a>
-        ))}
+            <span style={{ color: "#1C3A2A" }}>Build</span>
+            <span style={{ color: "#C84B1A" }}>Base</span>
+          </span>
+        </Link>
+      </div>
+
+      {/* Nav */}
+      <nav style={{ flex: 1, padding: "0 12px", overflowY: "auto" }}>
+        {items.map((item: NavItem) => {
+          const Icon = ICON_MAP[item.icon];
+          const isActive =
+            item.href === "/dashboard"
+              ? pathname === "/dashboard"
+              : pathname.startsWith(item.href);
+
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 10,
+                padding: "8px 12px",
+                borderRadius: 8,
+                color: isActive ? "#E8F0E8" : "#8A9E8A",
+                background: isActive ? "#22332A" : "transparent",
+                textDecoration: "none",
+                fontSize: 14,
+                fontWeight: isActive ? 600 : 500,
+                marginBottom: 2,
+                transition: "background 0.1s, color 0.1s",
+              }}
+            >
+              {Icon && <Icon size={16} />}
+              {item.label}
+            </Link>
+          );
+        })}
       </nav>
+
+      {/* Role badge */}
+      <div style={{ padding: "12px 20px", borderTop: "1px solid #2A3D30" }}>
+        <span
+          style={{
+            fontSize: 11,
+            fontWeight: 600,
+            textTransform: "uppercase",
+            letterSpacing: "0.08em",
+            color: "#4A5A4A",
+          }}
+        >
+          {role}
+        </span>
+      </div>
     </aside>
   );
 }

--- a/lib/profile.ts
+++ b/lib/profile.ts
@@ -1,0 +1,50 @@
+import type { UserRole } from "@/lib/types";
+
+/**
+ * Returns the nav items a given role should see in the sidebar.
+ * Keeps nav config in one place and makes it unit-testable.
+ */
+export interface NavItem {
+  label: string;
+  href: string;
+  /** lucide-react icon name */
+  icon: string;
+}
+
+export function getNavItems(role: UserRole, hasCoach: boolean): NavItem[] {
+  const userItems: NavItem[] = [
+    { label: "Dashboard", href: "/dashboard", icon: "LayoutDashboard" },
+    { label: "Sessions", href: "/sessions", icon: "Dumbbell" },
+    { label: "Progress", href: "/progress", icon: "TrendingUp" },
+  ];
+
+  if (hasCoach) {
+    userItems.push({ label: "Coach's Notes", href: "/coach-notes", icon: "MessageSquare" });
+  }
+
+  const coachItems: NavItem[] = [
+    { label: "Clients", href: "/clients", icon: "Users" },
+    { label: "Playbook", href: "/playbook", icon: "BookOpen" },
+  ];
+
+  const adminItems: NavItem[] = [
+    { label: "Users", href: "/admin/users", icon: "UserCog" },
+    { label: "Programs", href: "/admin/programs", icon: "ClipboardList" },
+  ];
+
+  if (role === "admin") {
+    return [...userItems, ...coachItems, ...adminItems];
+  }
+  if (role === "coach") {
+    return [...userItems, ...coachItems];
+  }
+  return userItems;
+}
+
+/**
+ * Returns true when the user needs to complete onboarding before accessing
+ * the app.  Kept pure so it can be called from both proxy.ts and layouts.
+ */
+export function needsOnboarding(onboarding_done: boolean): boolean {
+  return !onboarding_done;
+}

--- a/lib/rbac.ts
+++ b/lib/rbac.ts
@@ -1,0 +1,43 @@
+import type { UserRole } from "@/lib/types";
+
+/**
+ * Returns the minimum role required to access a given pathname, or null if
+ * no special role is needed (any authenticated user may proceed).
+ */
+export function getRequiredRole(pathname: string): UserRole | null {
+  if (
+    pathname.startsWith("/admin") ||
+    pathname.startsWith("/admin/")
+  ) {
+    return "admin";
+  }
+
+  if (
+    pathname.startsWith("/clients") ||
+    pathname.startsWith("/playbook")
+  ) {
+    return "coach";
+  }
+
+  return null;
+}
+
+/**
+ * Returns true if the given role is allowed to access a route that requires
+ * `requiredRole`.  Admins can access everything.
+ */
+export function canAccess(userRole: UserRole, requiredRole: UserRole): boolean {
+  if (userRole === "admin") return true;
+  if (requiredRole === "coach") return userRole === "coach";
+  return false;
+}
+
+/**
+ * Convenience: given a pathname and user role, returns true if the user is
+ * allowed to visit the route.
+ */
+export function isRouteAllowed(pathname: string, userRole: UserRole): boolean {
+  const required = getRequiredRole(pathname);
+  if (!required) return true;
+  return canAccess(userRole, required);
+}

--- a/lib/roadmap-data.ts
+++ b/lib/roadmap-data.ts
@@ -54,9 +54,10 @@ export const ROADMAP: RoadmapBatch[] = [
         id: "1-2",
         title: "Role-based routing + RLS policies",
         description: "proxy.ts guards per role, all tables have RLS policies enforcing admin/coach/user access.",
-        status: "not-started",
-        tests: false,
+        status: "in-progress",
+        tests: true,
         branch: "feat/batch-1-rbac",
+        pr: 8,
         scope: {
           owns: ["proxy.ts"],
           avoid: ["app/(auth)/", "scripts/"],

--- a/lib/roadmap-data.ts
+++ b/lib/roadmap-data.ts
@@ -67,9 +67,10 @@ export const ROADMAP: RoadmapBatch[] = [
         id: "1-3",
         title: "Profile creation on first login",
         description: "After OAuth callback, create profiles row if missing. Onboarding flag set to false.",
-        status: "not-started",
-        tests: false,
+        status: "in-progress",
+        tests: true,
         branch: "feat/batch-1-profiles",
+        pr: 9,
         scope: {
           owns: ["app/auth/callback/"],
           avoid: ["proxy.ts", "scripts/"],

--- a/lib/roadmap-data.ts
+++ b/lib/roadmap-data.ts
@@ -80,9 +80,10 @@ export const ROADMAP: RoadmapBatch[] = [
         id: "1-4",
         title: "Seed script: default 12-week program",
         description: "36 sessions, all exercises with default weights per tier + gender, insertable via admin panel or script.",
-        status: "not-started",
-        tests: false,
+        status: "in-progress",
+        tests: true,
         branch: "feat/batch-1-seed",
+        pr: 10,
         scope: {
           owns: ["scripts/seed.ts", "supabase/seed.sql"],
           avoid: ["app/(auth)/", "proxy.ts"],

--- a/lib/seed-validation.ts
+++ b/lib/seed-validation.ts
@@ -1,0 +1,96 @@
+/**
+ * Pure helpers for validating seed data shape.
+ * Used in tests — no DB dependency.
+ */
+
+export interface SeedPhase {
+  phase_number: number;
+  week_start: number;
+  week_end: number;
+  name: string;
+}
+
+export interface SeedSession {
+  week_number: number;
+  session_number: number;
+  day_label: "A" | "B" | "C";
+  phase_number: number;
+}
+
+export interface SeedExercise {
+  is_bodyweight: boolean;
+  weight_pre_baseline_f: number;
+  weight_pre_baseline_m: number;
+  weight_default_f: number;
+  weight_default_m: number;
+  weight_post_baseline_f: number;
+  weight_post_baseline_m: number;
+  is_abs_finisher: boolean;
+  sets_default: number;
+  reps_default: number;
+}
+
+/** Validates phase structure covers exactly 12 weeks with no gaps */
+export function validatePhasesCover12Weeks(phases: SeedPhase[]): boolean {
+  if (phases.length !== 3) return false;
+  const sorted = [...phases].sort((a, b) => a.week_start - b.week_start);
+  if (sorted[0].week_start !== 1) return false;
+  if (sorted[sorted.length - 1].week_end !== 12) return false;
+  for (let i = 1; i < sorted.length; i++) {
+    if (sorted[i].week_start !== sorted[i - 1].week_end + 1) return false;
+  }
+  return true;
+}
+
+/** Validates a session list contains exactly 36 sessions (3 per week × 12 weeks) */
+export function validateSessionCount(sessions: SeedSession[]): boolean {
+  return sessions.length === 36;
+}
+
+/** Validates each week has exactly one A, B, and C session */
+export function validateSessionsPerWeek(sessions: SeedSession[]): boolean {
+  const weeks = new Map<number, Set<string>>();
+  for (const s of sessions) {
+    if (!weeks.has(s.week_number)) weeks.set(s.week_number, new Set());
+    weeks.get(s.week_number)!.add(s.day_label);
+  }
+  if (weeks.size !== 12) return false;
+  for (const labels of weeks.values()) {
+    if (!labels.has("A") || !labels.has("B") || !labels.has("C")) return false;
+    if (labels.size !== 3) return false;
+  }
+  return true;
+}
+
+/** Validates that a non-bodyweight exercise has all 6 weight defaults set */
+export function validateWeightDefaults(exercise: SeedExercise): boolean {
+  if (exercise.is_bodyweight) return true;
+  return (
+    exercise.weight_pre_baseline_f >= 0 &&
+    exercise.weight_pre_baseline_m >= 0 &&
+    exercise.weight_default_f >= 0 &&
+    exercise.weight_default_m >= 0 &&
+    exercise.weight_post_baseline_f >= 0 &&
+    exercise.weight_post_baseline_m >= 0
+  );
+}
+
+/** Validates that male defaults are >= female defaults (sanity check) */
+export function validateMaleGeqFemale(exercise: SeedExercise): boolean {
+  if (exercise.is_bodyweight) return true;
+  return (
+    exercise.weight_pre_baseline_m >= exercise.weight_pre_baseline_f &&
+    exercise.weight_default_m >= exercise.weight_default_f &&
+    exercise.weight_post_baseline_m >= exercise.weight_post_baseline_f
+  );
+}
+
+/** Validates sets and reps are within reasonable ranges */
+export function validateSetsReps(exercise: SeedExercise): boolean {
+  return (
+    exercise.sets_default >= 1 &&
+    exercise.sets_default <= 6 &&
+    exercise.reps_default >= 0 && // 0 = time-based (plank, hollow body)
+    exercise.reps_default <= 20
+  );
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createServerClient, type CookieOptions } from "@supabase/ssr";
 import { MONITOR_COOKIE, MONITOR_LOGIN_PATH } from "@/lib/constants";
+import { isRouteAllowed } from "@/lib/rbac";
+import type { UserRole } from "@/lib/types";
 
 export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
@@ -60,6 +62,27 @@ export async function proxy(request: NextRequest) {
 
   if (user && isAuthRoute) {
     return NextResponse.redirect(new URL("/dashboard", request.url));
+  }
+
+  // ── Role-based route protection ───────────────────────────────────────────
+  // Only query the DB when the route actually requires a specific role.
+  if (user) {
+    const isCoachRoute = pathname.startsWith("/clients") || pathname.startsWith("/playbook");
+    const isAdminRoute = pathname.startsWith("/admin");
+
+    if (isCoachRoute || isAdminRoute) {
+      const { data: profile } = await supabase
+        .from("profiles")
+        .select("role")
+        .eq("id", user.id)
+        .single();
+
+      const role = (profile?.role ?? "user") as UserRole;
+
+      if (!isRouteAllowed(pathname, role)) {
+        return NextResponse.redirect(new URL("/dashboard", request.url));
+      }
+    }
   }
 
   return response;

--- a/proxy.ts
+++ b/proxy.ts
@@ -52,7 +52,11 @@ export async function proxy(request: NextRequest) {
     pathname.startsWith("/forgot-password") ||
     pathname.startsWith("/reset-password");
   const isPublicRoute =
-    pathname === "/" || isAuthRoute || pathname.startsWith("/monitor") || pathname.startsWith("/auth");
+    pathname === "/" ||
+    isAuthRoute ||
+    pathname.startsWith("/monitor") ||
+    pathname.startsWith("/auth") ||
+    pathname.startsWith("/onboarding");
 
   if (!user && !isPublicRoute) {
     const loginUrl = new URL("/login", request.url);

--- a/proxy.ts
+++ b/proxy.ts
@@ -55,6 +55,7 @@ export async function proxy(request: NextRequest) {
     pathname === "/" ||
     isAuthRoute ||
     pathname.startsWith("/monitor") ||
+    pathname.startsWith("/api/monitor/") ||
     pathname.startsWith("/auth") ||
     pathname.startsWith("/onboarding");
 

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,372 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- BuildBase — 12-Week Default Program Seed
+--
+-- Run ONCE in Supabase SQL Editor on a fresh database AFTER 001_initial_schema.sql.
+-- This seed is NOT idempotent — running it twice will create duplicate records.
+-- To re-seed: DELETE FROM programs WHERE name = 'BuildBase 12-Week Foundation';
+-- ─────────────────────────────────────────────────────────────────────────────
+
+DO $$
+DECLARE
+  -- IDs
+  prog_id       uuid := gen_random_uuid();
+
+  phase1_id     uuid := gen_random_uuid();
+  phase2_id     uuid := gen_random_uuid();
+  phase3_id     uuid := gen_random_uuid();
+
+  -- Phase 1 workout templates (weeks 1-4, sessions A/B/C × 4 weeks = 12)
+  p1w1a uuid := gen_random_uuid(); p1w1b uuid := gen_random_uuid(); p1w1c uuid := gen_random_uuid();
+  p1w2a uuid := gen_random_uuid(); p1w2b uuid := gen_random_uuid(); p1w2c uuid := gen_random_uuid();
+  p1w3a uuid := gen_random_uuid(); p1w3b uuid := gen_random_uuid(); p1w3c uuid := gen_random_uuid();
+  p1w4a uuid := gen_random_uuid(); p1w4b uuid := gen_random_uuid(); p1w4c uuid := gen_random_uuid();
+
+  -- Phase 2 workout templates (weeks 5-8)
+  p2w5a uuid := gen_random_uuid(); p2w5b uuid := gen_random_uuid(); p2w5c uuid := gen_random_uuid();
+  p2w6a uuid := gen_random_uuid(); p2w6b uuid := gen_random_uuid(); p2w6c uuid := gen_random_uuid();
+  p2w7a uuid := gen_random_uuid(); p2w7b uuid := gen_random_uuid(); p2w7c uuid := gen_random_uuid();
+  p2w8a uuid := gen_random_uuid(); p2w8b uuid := gen_random_uuid(); p2w8c uuid := gen_random_uuid();
+
+  -- Phase 3 workout templates (weeks 9-12)
+  p3w9a  uuid := gen_random_uuid(); p3w9b  uuid := gen_random_uuid(); p3w9c  uuid := gen_random_uuid();
+  p3w10a uuid := gen_random_uuid(); p3w10b uuid := gen_random_uuid(); p3w10c uuid := gen_random_uuid();
+  p3w11a uuid := gen_random_uuid(); p3w11b uuid := gen_random_uuid(); p3w11c uuid := gen_random_uuid();
+  p3w12a uuid := gen_random_uuid(); p3w12b uuid := gen_random_uuid(); p3w12c uuid := gen_random_uuid();
+
+  -- Exercise IDs
+  e_smith_squat       uuid := gen_random_uuid();
+  e_goblet_squat      uuid := gen_random_uuid();
+  e_bb_back_squat     uuid := gen_random_uuid();
+  e_ham_curl          uuid := gen_random_uuid();
+  e_walking_lunge     uuid := gen_random_uuid();
+  e_bw_hip_thrust     uuid := gen_random_uuid();
+  e_bb_hip_thrust     uuid := gen_random_uuid();
+  e_db_shoulder_press uuid := gen_random_uuid();
+  e_lateral_raise     uuid := gen_random_uuid();
+  e_rear_delt_fly     uuid := gen_random_uuid();
+  e_crunch            uuid := gen_random_uuid();
+  e_leg_raise         uuid := gen_random_uuid();
+  e_plank             uuid := gen_random_uuid();
+  e_dead_bug          uuid := gen_random_uuid();
+  e_bic_curl_sup      uuid := gen_random_uuid();
+  e_skull_crusher     uuid := gen_random_uuid();
+  e_hammer_curl       uuid := gen_random_uuid();
+  e_tri_kickback      uuid := gen_random_uuid();
+  e_rdl               uuid := gen_random_uuid();
+  e_one_arm_row       uuid := gen_random_uuid();
+  e_db_chest_press    uuid := gen_random_uuid();
+  e_bicep_curl        uuid := gen_random_uuid();
+  e_tri_pushdown      uuid := gen_random_uuid();
+  e_trap_bar_dl       uuid := gen_random_uuid();
+  e_conv_dl           uuid := gen_random_uuid();
+  e_lat_pulldown      uuid := gen_random_uuid();
+  e_seated_cable_row  uuid := gen_random_uuid();
+  e_incline_pushup    uuid := gen_random_uuid();
+  e_floor_pushup      uuid := gen_random_uuid();
+  e_face_pull         uuid := gen_random_uuid();
+  e_bicycle_crunch    uuid := gen_random_uuid();
+  e_hollow_body       uuid := gen_random_uuid();
+
+BEGIN
+
+-- ─── Program ─────────────────────────────────────────────────────────────────
+INSERT INTO programs (id, name, description, total_phases, total_weeks, version, is_active)
+VALUES (
+  prog_id,
+  'BuildBase 12-Week Foundation',
+  'A structured 3-phase beginner strength program. Phase 1 focuses on form, Phase 2 introduces progressive load, Phase 3 builds foundational strength with barbell compounds.',
+  3, 12, 1, true
+);
+
+-- ─── Phases ──────────────────────────────────────────────────────────────────
+INSERT INTO phases (id, program_id, phase_number, name, subtitle, week_start, week_end, description) VALUES
+(phase1_id, prog_id, 1, 'Foundation',        'Form first, weight second',      1,  4,  'Build movement patterns with controlled loads. 3× 8 reps every set with 3+ reps in tank. No ego — this is where habits form.'),
+(phase2_id, prog_id, 2, 'Load Introduction', 'Progressive overload begins',    5,  8,  '3×8 lower body with +5 lb weekly increments. 3×10 upper body. Day B becomes full-body.'),
+(phase3_id, prog_id, 3, 'Strength',          'Compounds, power, PRs',          9,  12, '4×6 lower body. 3×12 upper body. Barbell back squat and conventional deadlift introduced.');
+
+-- ─── Exercises ───────────────────────────────────────────────────────────────
+INSERT INTO exercises (id, name, muscle_group, equipment, coaching_cues, is_active) VALUES
+(e_smith_squat,       'Smith Machine Squat',       'Quads, Glutes',        'Smith Machine',    'Feet shoulder-width, toes 15° out. Break at hips and knees simultaneously. Keep chest tall, knees tracking over toes.',                            true),
+(e_goblet_squat,      'Goblet Squat',              'Quads, Glutes, Core',  'Dumbbell/Kettlebell', 'Hold weight at chest. Elbows inside knees at bottom. Drive up through full foot.',                                                             true),
+(e_bb_back_squat,     'Barbell Back Squat',        'Quads, Glutes, Core',  'Barbell, Rack',    'Bar on traps, not neck. Brace core before descent. Depth: hip crease below parallel. Drive knees out on ascent.',                                 true),
+(e_ham_curl,          'Hamstring Curl Machine',    'Hamstrings',           'Machine',          'Slow 2-second eccentric. Squeeze at top. Do not jerk the weight up.',                                                                               true),
+(e_walking_lunge,     'Walking Lunges',            'Quads, Glutes, Balance','Bodyweight/DBs',  'Big step, back knee hovers 1 inch off floor. Front knee stays above ankle. Stand fully before next step.',                                         true),
+(e_bw_hip_thrust,     'Bodyweight Hip Thrust',     'Glutes',               'Bench',            'Upper back on bench edge, feet flat. Drive hips up to full extension. Squeeze glutes at top for 1 second.',                                        true),
+(e_bb_hip_thrust,     'Barbell Hip Thrust',        'Glutes',               'Barbell, Bench',   'Pad on bar. Upper back on bench. Drive through heels, full hip extension. Do not hyperextend lumbar.',                                             true),
+(e_db_shoulder_press, 'DB Shoulder Press',         'Shoulders',            'Dumbbells',        'Press straight up, slight forward lean acceptable. Stop just short of lockout. Control the descent.',                                              true),
+(e_lateral_raise,     'Lateral Raises',            'Lateral Deltoids',     'Dumbbells',        'Slight elbow bend. Lead with elbows, not hands. Stop at shoulder height. Slow 3-second eccentric.',                                                true),
+(e_rear_delt_fly,     'Rear Delt Fly',             'Rear Deltoids',        'Dumbbells',        'Hinge at hips, chest parallel to floor. Arms arc out to sides, thumbs pointing down. Squeeze shoulder blades.',                                   true),
+(e_crunch,            'Crunches',                  'Abs',                  'Bodyweight',       'Hands behind head, elbows wide. Curl shoulder blades off floor — do not pull neck. Exhale at top.',                                                true),
+(e_leg_raise,         'Leg Raises',                'Lower Abs',            'Bodyweight',       'Lower back pressed into floor. Legs together, lower to just above floor — do not touch. Raise controlled.',                                        true),
+(e_plank,             'Plank',                     'Core',                 'Bodyweight',       'Forearms under shoulders. Hips level — no sagging or piking. Breathe. Brace as if taking a punch.',                                                true),
+(e_dead_bug,          'Dead Bug',                  'Core, Anti-rotation',  'Bodyweight',       'Lower back glued to floor the entire time. Opposite arm and leg lower slowly. Exhale as limbs lower.',                                             true),
+(e_bic_curl_sup,      'Supinating Bicep Curl',     'Biceps',               'Dumbbells',        'Start with palms facing in, rotate to palms-up at top. Full supination. Squeeze at top, slow on the way down.',                                   true),
+(e_skull_crusher,     'Skull Crusher',             'Triceps',              'Dumbbells',        'Upper arms vertical, only forearms move. Lower to temples — do not flare elbows wide. Press straight up.',                                         true),
+(e_hammer_curl,       'Hammer Curl',               'Brachialis, Biceps',   'Dumbbells',        'Neutral grip (palms facing in) throughout. Do not swing. Both arms or alternating, full range of motion.',                                         true),
+(e_tri_kickback,      'Tricep Kickback',           'Triceps',              'Dumbbells',        'Hinge forward. Upper arm parallel to floor. Extend fully — squeeze tricep hard at lockout. Control descent.',                                      true),
+(e_rdl,               'Romanian Deadlift',         'Hamstrings, Glutes',   'Dumbbells',        'Soft knee bend, hinge at hips. Bar (or DBs) close to legs. Feel hamstring stretch. Drive hips forward to stand.',                                 true),
+(e_one_arm_row,       'One-Arm DB Row',            'Lats, Rhomboids',      'Dumbbell, Bench',  'Brace on bench. Pull elbow to hip, not shoulder. Full extension at bottom. Do not rotate torso.',                                                  true),
+(e_db_chest_press,    'DB Chest Press',            'Chest, Triceps',       'Dumbbells, Bench', 'Press up and slightly together. Do not lock out. Control descent — elbows 45° from torso, not flared.',                                           true),
+(e_bicep_curl,        'Bicep Curl',                'Biceps',               'Dumbbells',        'Elbows pinned to sides. No swinging. Full extension at bottom. Squeeze at top.',                                                                   true),
+(e_tri_pushdown,      'Tricep Pushdown',           'Triceps',              'Cable Machine',    'Elbows at sides, press down to full extension. Squeeze. Controlled return — do not let elbows drift forward.',                                     true),
+(e_trap_bar_dl,       'Trap Bar Deadlift',         'Hamstrings, Glutes, Back', 'Trap Bar',     'Stand in center of bar. Hip hinge to grip. Brace, then drive floor away. Hips and shoulders rise together.',                                      true),
+(e_conv_dl,           'Conventional Deadlift',     'Posterior Chain',      'Barbell',          'Bar over mid-foot. Hip-width stance. Hinge, grip just outside shins. Brace hard. Drive hips and shoulders up together. Bar stays close.',          true),
+(e_lat_pulldown,      'Lat Pulldown',              'Lats',                 'Cable Machine',    'Lean back slightly. Pull bar to upper chest, lead with elbows. Squeeze lats at bottom. Slow return.',                                              true),
+(e_seated_cable_row,  'Seated Cable Row',          'Rhomboids, Lats',      'Cable Machine',    'Sit tall. Pull handle to navel — squeeze shoulder blades together. Do not rock torso. Slow controlled return.',                                    true),
+(e_incline_pushup,    'Incline Push-up',           'Chest, Triceps, Core', 'Bench/Box',        'Hands on elevated surface, body straight plank. Lower chest to surface. Elbows 45°. Full range.',                                                 true),
+(e_floor_pushup,      'Push-up',                   'Chest, Triceps, Core', 'Bodyweight',       'Hands shoulder-width, body rigid plank. Chest touches floor. Drive back to full arm extension.',                                                   true),
+(e_face_pull,         'Face Pull',                 'Rear Delts, Rotator Cuff', 'Cable Machine', 'Rope attachment at forehead height. Pull to face, elbows flare out. External rotation at end. Non-negotiable for shoulder health.',              true),
+(e_bicycle_crunch,    'Bicycle Crunches',          'Obliques, Abs',        'Bodyweight',       'Rotate shoulder to opposite knee. Full extension of leg. Do not pull neck. Slow and controlled — not a race.',                                     true),
+(e_hollow_body,       'Hollow Body Hold',          'Core',                 'Bodyweight',       'Arms overhead, lower back pressed to floor. Lift legs and shoulders. Hold. The lower the legs, the harder it is — start higher.',                  true);
+
+-- ─── Workout Templates ───────────────────────────────────────────────────────
+-- Phase 1 (weeks 1–4): Day A = Legs+Shoulders, Day B = Arms, Day C = Chest+Back+DL
+INSERT INTO workout_templates (id, phase_id, week_number, session_number, day_label, title, order_index) VALUES
+-- Week 1
+(p1w1a, phase1_id, 1, 1, 'A', 'Week 1 — Day A: Legs + Shoulders', 1),
+(p1w1b, phase1_id, 1, 2, 'B', 'Week 1 — Day B: Arms',              2),
+(p1w1c, phase1_id, 1, 3, 'C', 'Week 1 — Day C: Chest + Back',      3),
+-- Week 2
+(p1w2a, phase1_id, 2, 4, 'A', 'Week 2 — Day A: Legs + Shoulders', 4),
+(p1w2b, phase1_id, 2, 5, 'B', 'Week 2 — Day B: Arms',              5),
+(p1w2c, phase1_id, 2, 6, 'C', 'Week 2 — Day C: Chest + Back',      6),
+-- Week 3
+(p1w3a, phase1_id, 3, 7,  'A', 'Week 3 — Day A: Legs + Shoulders', 7),
+(p1w3b, phase1_id, 3, 8,  'B', 'Week 3 — Day B: Arms',              8),
+(p1w3c, phase1_id, 3, 9,  'C', 'Week 3 — Day C: Chest + Back',      9),
+-- Week 4
+(p1w4a, phase1_id, 4, 10, 'A', 'Week 4 — Day A: Legs + Shoulders', 10),
+(p1w4b, phase1_id, 4, 11, 'B', 'Week 4 — Day B: Arms',              11),
+(p1w4c, phase1_id, 4, 12, 'C', 'Week 4 — Day C: Chest + Back',      12);
+
+-- Phase 2 (weeks 5–8): Day A = Legs+Shoulders, Day B = Full Body, Day C = Chest+Back+DL
+INSERT INTO workout_templates (id, phase_id, week_number, session_number, day_label, title, order_index) VALUES
+(p2w5a, phase2_id, 5, 13, 'A', 'Week 5 — Day A: Legs + Shoulders', 13),
+(p2w5b, phase2_id, 5, 14, 'B', 'Week 5 — Day B: Full Body',         14),
+(p2w5c, phase2_id, 5, 15, 'C', 'Week 5 — Day C: Chest + Back',      15),
+(p2w6a, phase2_id, 6, 16, 'A', 'Week 6 — Day A: Legs + Shoulders', 16),
+(p2w6b, phase2_id, 6, 17, 'B', 'Week 6 — Day B: Full Body',         17),
+(p2w6c, phase2_id, 6, 18, 'C', 'Week 6 — Day C: Chest + Back',      18),
+(p2w7a, phase2_id, 7, 19, 'A', 'Week 7 — Day A: Legs + Shoulders', 19),
+(p2w7b, phase2_id, 7, 20, 'B', 'Week 7 — Day B: Full Body',         20),
+(p2w7c, phase2_id, 7, 21, 'C', 'Week 7 — Day C: Chest + Back',      21),
+(p2w8a, phase2_id, 8, 22, 'A', 'Week 8 — Day A: Legs + Shoulders', 22),
+(p2w8b, phase2_id, 8, 23, 'B', 'Week 8 — Day B: Full Body',         23),
+(p2w8c, phase2_id, 8, 24, 'C', 'Week 8 — Day C: Chest + Back',      24);
+
+-- Phase 3 (weeks 9–12): Day A = Legs+Shoulders (barbell), Day B = Full Body, Day C = Chest+Back+Conv DL
+INSERT INTO workout_templates (id, phase_id, week_number, session_number, day_label, title, order_index) VALUES
+(p3w9a,  phase3_id, 9,  25, 'A', 'Week 9 — Day A: Legs + Shoulders',  25),
+(p3w9b,  phase3_id, 9,  26, 'B', 'Week 9 — Day B: Full Body',          26),
+(p3w9c,  phase3_id, 9,  27, 'C', 'Week 9 — Day C: Chest + Back',       27),
+(p3w10a, phase3_id, 10, 28, 'A', 'Week 10 — Day A: Legs + Shoulders', 28),
+(p3w10b, phase3_id, 10, 29, 'B', 'Week 10 — Day B: Full Body',         29),
+(p3w10c, phase3_id, 10, 30, 'C', 'Week 10 — Day C: Chest + Back',      30),
+(p3w11a, phase3_id, 11, 31, 'A', 'Week 11 — Day A: Legs + Shoulders', 31),
+(p3w11b, phase3_id, 11, 32, 'B', 'Week 11 — Day B: Full Body',         32),
+(p3w11c, phase3_id, 11, 33, 'C', 'Week 11 — Day C: Chest + Back',      33),
+(p3w12a, phase3_id, 12, 34, 'A', 'Week 12 — Day A: Legs + Shoulders', 34),
+(p3w12b, phase3_id, 12, 35, 'B', 'Week 12 — Day B: Full Body',         35),
+(p3w12c, phase3_id, 12, 36, 'C', 'Week 12 — Day C: Chest + Back',      36);
+
+-- ─── Template Exercises ──────────────────────────────────────────────────────
+-- Weight columns: (pre_baseline_f, pre_baseline_m, default_f, default_m, post_baseline_f, post_baseline_m)
+-- is_bodyweight exercises use 0 for all weight columns.
+--
+-- Phase 1 Day A — Legs + Shoulders
+-- Smith Machine Squat → Hamstring Curl → Walking Lunge → BW Hip Thrust → DB Shoulder Press → Lateral Raises → Rear Delt Fly → Abs (Crunches + Leg Raises)
+
+-- Helper to insert all 12 phase-1 Day A sessions identically
+-- (We insert once per template to keep the seed concise but fully populated)
+
+-- PHASE 1 — Day A sessions (4 weeks)
+DO $inner$
+DECLARE
+  templates uuid[] := ARRAY[p1w1a, p1w2a, p1w3a, p1w4a];
+  t uuid;
+BEGIN
+  FOREACH t IN ARRAY templates LOOP
+    INSERT INTO template_exercises (workout_template_id, exercise_id, order_index, sets_default, reps_default,
+      weight_pre_baseline_f, weight_pre_baseline_m, weight_default_f, weight_default_m, weight_post_baseline_f, weight_post_baseline_m,
+      is_bodyweight, is_abs_finisher) VALUES
+    (t, e_smith_squat,       1, 3, 8,   0,    45,   45,   55,   0,    0,    false, false),  -- post_baseline skips smith → 0
+    (t, e_ham_curl,          2, 3, 8,   30,   40,   40,   55,   55,   75,   false, false),
+    (t, e_walking_lunge,     3, 3, 8,   0,    0,    0,    0,    0,    0,    true,  false),   -- bodyweight
+    (t, e_bw_hip_thrust,     4, 3, 8,   0,    0,    0,    0,    0,    0,    true,  false),   -- BW phase 1
+    (t, e_db_shoulder_press, 5, 3, 8,   5,    8,    7.5,  12.5, 12.5, 17.5, false, false),
+    (t, e_lateral_raise,     6, 3, 8,   3,    5,    5,    8,    8,    10,   false, false),
+    (t, e_rear_delt_fly,     7, 3, 8,   3,    5,    5,    8,    8,    10,   false, false),
+    (t, e_crunch,            8, 2, 15,  0,    0,    0,    0,    0,    0,    true,  true),
+    (t, e_leg_raise,         9, 2, 10,  0,    0,    0,    0,    0,    0,    true,  true);
+  END LOOP;
+END $inner$;
+
+-- PHASE 1 — Day B sessions (4 weeks): Arms
+DO $inner$
+DECLARE
+  templates uuid[] := ARRAY[p1w1b, p1w2b, p1w3b, p1w4b];
+  t uuid;
+BEGIN
+  FOREACH t IN ARRAY templates LOOP
+    INSERT INTO template_exercises (workout_template_id, exercise_id, order_index, sets_default, reps_default,
+      weight_pre_baseline_f, weight_pre_baseline_m, weight_default_f, weight_default_m, weight_post_baseline_f, weight_post_baseline_m,
+      is_bodyweight, is_abs_finisher, superset_group) VALUES
+    (t, e_bic_curl_sup,  1, 3, 8,  5,  8,  10,  15,  12.5, 17.5, false, false, 'A'),
+    (t, e_skull_crusher, 2, 3, 8,  5,  8,  8,   12.5, 10,  15,   false, false, 'A'),
+    (t, e_hammer_curl,   3, 3, 8,  5,  8,  10,  15,  12.5, 17.5, false, false, 'B'),
+    (t, e_tri_kickback,  4, 3, 8,  3,  5,  5,   8,   8,    10,   false, false, 'B'),
+    (t, e_plank,         5, 2, 0,  0,  0,  0,   0,   0,    0,    true,  true,  null),  -- reps_default=0 → time-based (20–30s)
+    (t, e_dead_bug,      6, 2, 8,  0,  0,  0,   0,   0,    0,    true,  true,  null);
+  END LOOP;
+END $inner$;
+
+-- PHASE 1 — Day C sessions (4 weeks): Chest + Back + Trap Bar DL
+DO $inner$
+DECLARE
+  templates uuid[] := ARRAY[p1w1c, p1w2c, p1w3c, p1w4c];
+  t uuid;
+BEGIN
+  FOREACH t IN ARRAY templates LOOP
+    INSERT INTO template_exercises (workout_template_id, exercise_id, order_index, sets_default, reps_default,
+      weight_pre_baseline_f, weight_pre_baseline_m, weight_default_f, weight_default_m, weight_post_baseline_f, weight_post_baseline_m,
+      is_bodyweight, is_abs_finisher) VALUES
+    (t, e_trap_bar_dl,      1, 3, 8,  45,  65,  65,  95,  95,  135, false, false),  -- ALWAYS FIRST
+    (t, e_lat_pulldown,     2, 3, 8,  30,  40,  40,  60,  60,  80,  false, false),
+    (t, e_seated_cable_row, 3, 3, 8,  30,  40,  40,  60,  60,  80,  false, false),
+    (t, e_db_chest_press,   4, 3, 8,  8,   12.5,12.5,20,  17.5,25,  false, false),
+    (t, e_incline_pushup,   5, 3, 8,  0,   0,   0,   0,   0,   0,   true,  false),
+    (t, e_face_pull,        6, 3, 12, 15,  20,  20,  30,  30,  40,  false, false),
+    (t, e_bicycle_crunch,   7, 2, 15, 0,   0,   0,   0,   0,   0,   true,  true),
+    (t, e_hollow_body,      8, 2, 0,  0,   0,   0,   0,   0,   0,   true,  true);   -- reps_default=0 → time-based (15–20s)
+  END LOOP;
+END $inner$;
+
+-- PHASE 2 — Day A sessions (4 weeks): Goblet Squat + Barbell Hip Thrust introduced
+DO $inner$
+DECLARE
+  templates uuid[] := ARRAY[p2w5a, p2w6a, p2w7a, p2w8a];
+  t uuid;
+BEGIN
+  FOREACH t IN ARRAY templates LOOP
+    INSERT INTO template_exercises (workout_template_id, exercise_id, order_index, sets_default, reps_default,
+      weight_pre_baseline_f, weight_pre_baseline_m, weight_default_f, weight_default_m, weight_post_baseline_f, weight_post_baseline_m,
+      is_bodyweight, is_abs_finisher) VALUES
+    (t, e_goblet_squat,      1, 3, 8,  10,  15,  15,  25,  25,  35,  false, false),
+    (t, e_ham_curl,          2, 3, 8,  30,  40,  40,  55,  55,  75,  false, false),
+    (t, e_walking_lunge,     3, 3, 8,  0,   0,   0,   0,   0,   0,   true,  false),
+    (t, e_bb_hip_thrust,     4, 3, 8,  45,  45,  45,  65,  65,  95,  false, false),
+    (t, e_db_shoulder_press, 5, 3, 10, 5,   8,   7.5, 12.5,12.5,17.5,false, false),
+    (t, e_lateral_raise,     6, 3, 10, 3,   5,   5,   8,   8,   10,  false, false),
+    (t, e_rear_delt_fly,     7, 3, 10, 3,   5,   5,   8,   8,   10,  false, false),
+    (t, e_plank,             8, 2, 0,  0,   0,   0,   0,   0,   0,   true,  true),
+    (t, e_dead_bug,          9, 2, 8,  0,   0,   0,   0,   0,   0,   true,  true);
+  END LOOP;
+END $inner$;
+
+-- PHASE 2 — Day B sessions (4 weeks): Full Body
+DO $inner$
+DECLARE
+  templates uuid[] := ARRAY[p2w5b, p2w6b, p2w7b, p2w8b];
+  t uuid;
+BEGIN
+  FOREACH t IN ARRAY templates LOOP
+    INSERT INTO template_exercises (workout_template_id, exercise_id, order_index, sets_default, reps_default,
+      weight_pre_baseline_f, weight_pre_baseline_m, weight_default_f, weight_default_m, weight_post_baseline_f, weight_post_baseline_m,
+      is_bodyweight, is_abs_finisher) VALUES
+    (t, e_goblet_squat,  1, 3, 8,  10,  15,  15,  25,  25,  35,  false, false),
+    (t, e_rdl,           2, 3, 8,  20,  35,  35,  55,  55,  75,  false, false),
+    (t, e_one_arm_row,   3, 3, 10, 10,  15,  15,  25,  25,  35,  false, false),
+    (t, e_db_chest_press,4, 3, 10, 8,   12.5,12.5,20,  17.5,25,  false, false),
+    (t, e_bicep_curl,    5, 3, 10, 5,   8,   10,  15,  12.5,17.5,false, false),
+    (t, e_tri_pushdown,  6, 3, 10, 10,  15,  15,  25,  25,  35,  false, false),
+    (t, e_plank,         7, 2, 0,  0,   0,   0,   0,   0,   0,   true,  true),
+    (t, e_dead_bug,      8, 2, 8,  0,   0,   0,   0,   0,   0,   true,  true);
+  END LOOP;
+END $inner$;
+
+-- PHASE 2 — Day C sessions (4 weeks): Trap Bar DL
+DO $inner$
+DECLARE
+  templates uuid[] := ARRAY[p2w5c, p2w6c, p2w7c, p2w8c];
+  t uuid;
+BEGIN
+  FOREACH t IN ARRAY templates LOOP
+    INSERT INTO template_exercises (workout_template_id, exercise_id, order_index, sets_default, reps_default,
+      weight_pre_baseline_f, weight_pre_baseline_m, weight_default_f, weight_default_m, weight_post_baseline_f, weight_post_baseline_m,
+      is_bodyweight, is_abs_finisher) VALUES
+    (t, e_trap_bar_dl,      1, 3, 8,  45,  65,  65,  95,  95,  135, false, false),
+    (t, e_lat_pulldown,     2, 3, 10, 30,  40,  40,  60,  60,  80,  false, false),
+    (t, e_seated_cable_row, 3, 3, 10, 30,  40,  40,  60,  60,  80,  false, false),
+    (t, e_db_chest_press,   4, 3, 10, 8,   12.5,12.5,20,  17.5,25,  false, false),
+    (t, e_floor_pushup,     5, 3, 10, 0,   0,   0,   0,   0,   0,   true,  false),
+    (t, e_face_pull,        6, 3, 12, 15,  20,  20,  30,  30,  40,  false, false),
+    (t, e_bicycle_crunch,   7, 2, 15, 0,   0,   0,   0,   0,   0,   true,  true),
+    (t, e_hollow_body,      8, 2, 0,  0,   0,   0,   0,   0,   0,   true,  true);
+  END LOOP;
+END $inner$;
+
+-- PHASE 3 — Day A sessions (4 weeks): Barbell Back Squat
+DO $inner$
+DECLARE
+  templates uuid[] := ARRAY[p3w9a, p3w10a, p3w11a, p3w12a];
+  t uuid;
+BEGIN
+  FOREACH t IN ARRAY templates LOOP
+    INSERT INTO template_exercises (workout_template_id, exercise_id, order_index, sets_default, reps_default,
+      weight_pre_baseline_f, weight_pre_baseline_m, weight_default_f, weight_default_m, weight_post_baseline_f, weight_post_baseline_m,
+      is_bodyweight, is_abs_finisher) VALUES
+    (t, e_bb_back_squat,     1, 4, 6,  35,  55,  45,  65,  65,  95,  false, false),
+    (t, e_ham_curl,          2, 4, 6,  30,  40,  40,  55,  55,  75,  false, false),
+    (t, e_walking_lunge,     3, 3, 12, 0,   0,   0,   0,   0,   0,   true,  false),
+    (t, e_bb_hip_thrust,     4, 4, 6,  45,  65,  65,  95,  95,  135, false, false),
+    (t, e_db_shoulder_press, 5, 3, 12, 5,   8,   10,  15,  12.5,17.5,false, false),
+    (t, e_lateral_raise,     6, 3, 12, 3,   5,   5,   8,   8,   10,  false, false),
+    (t, e_rear_delt_fly,     7, 3, 12, 3,   5,   5,   8,   8,   10,  false, false),
+    (t, e_plank,             8, 2, 0,  0,   0,   0,   0,   0,   0,   true,  true),
+    (t, e_dead_bug,          9, 2, 8,  0,   0,   0,   0,   0,   0,   true,  true);
+  END LOOP;
+END $inner$;
+
+-- PHASE 3 — Day B sessions (4 weeks): Full Body
+DO $inner$
+DECLARE
+  templates uuid[] := ARRAY[p3w9b, p3w10b, p3w11b, p3w12b];
+  t uuid;
+BEGIN
+  FOREACH t IN ARRAY templates LOOP
+    INSERT INTO template_exercises (workout_template_id, exercise_id, order_index, sets_default, reps_default,
+      weight_pre_baseline_f, weight_pre_baseline_m, weight_default_f, weight_default_m, weight_post_baseline_f, weight_post_baseline_m,
+      is_bodyweight, is_abs_finisher) VALUES
+    (t, e_bb_back_squat, 1, 4, 6,  35,  55,  45,  65,  65,  95,  false, false),
+    (t, e_rdl,           2, 4, 6,  20,  35,  45,  65,  65,  95,  false, false),
+    (t, e_one_arm_row,   3, 3, 12, 10,  15,  20,  30,  30,  40,  false, false),
+    (t, e_db_chest_press,4, 3, 12, 8,   12.5,15,  22.5,20,  30,  false, false),
+    (t, e_bicep_curl,    5, 3, 12, 5,   8,   10,  15,  12.5,17.5,false, false),
+    (t, e_tri_pushdown,  6, 3, 12, 10,  15,  20,  30,  30,  40,  false, false),
+    (t, e_plank,         7, 2, 0,  0,   0,   0,   0,   0,   0,   true,  true),
+    (t, e_dead_bug,      8, 2, 8,  0,   0,   0,   0,   0,   0,   true,  true);
+  END LOOP;
+END $inner$;
+
+-- PHASE 3 — Day C sessions (4 weeks): Conventional Deadlift
+DO $inner$
+DECLARE
+  templates uuid[] := ARRAY[p3w9c, p3w10c, p3w11c, p3w12c];
+  t uuid;
+BEGIN
+  FOREACH t IN ARRAY templates LOOP
+    INSERT INTO template_exercises (workout_template_id, exercise_id, order_index, sets_default, reps_default,
+      weight_pre_baseline_f, weight_pre_baseline_m, weight_default_f, weight_default_m, weight_post_baseline_f, weight_post_baseline_m,
+      is_bodyweight, is_abs_finisher) VALUES
+    (t, e_conv_dl,          1, 4, 6,  65,  95,  95,  135, 135, 185, false, false),  -- ALWAYS FIRST
+    (t, e_lat_pulldown,     2, 3, 12, 30,  40,  45,  65,  65,  85,  false, false),
+    (t, e_seated_cable_row, 3, 3, 12, 30,  40,  45,  65,  65,  85,  false, false),
+    (t, e_db_chest_press,   4, 3, 12, 8,   12.5,15,  22.5,20,  30,  false, false),
+    (t, e_floor_pushup,     5, 3, 12, 0,   0,   0,   0,   0,   0,   true,  false),
+    (t, e_face_pull,        6, 3, 15, 15,  20,  20,  30,  30,  40,  false, false),
+    (t, e_bicycle_crunch,   7, 2, 15, 0,   0,   0,   0,   0,   0,   true,  true),
+    (t, e_hollow_body,      8, 2, 0,  0,   0,   0,   0,   0,   0,   true,  true);
+  END LOOP;
+END $inner$;
+
+END $$;

--- a/tests/profile.test.ts
+++ b/tests/profile.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { getNavItems, needsOnboarding } from "@/lib/profile";
+
+describe("getNavItems — user role", () => {
+  it("includes core user nav items", () => {
+    const items = getNavItems("user", false);
+    const hrefs = items.map((i) => i.href);
+    expect(hrefs).toContain("/dashboard");
+    expect(hrefs).toContain("/sessions");
+    expect(hrefs).toContain("/progress");
+  });
+
+  it("excludes coach-notes when no coach", () => {
+    const items = getNavItems("user", false);
+    expect(items.map((i) => i.href)).not.toContain("/coach-notes");
+  });
+
+  it("includes coach-notes when user has a coach", () => {
+    const items = getNavItems("user", true);
+    expect(items.map((i) => i.href)).toContain("/coach-notes");
+  });
+
+  it("excludes coach and admin items", () => {
+    const items = getNavItems("user", false);
+    const hrefs = items.map((i) => i.href);
+    expect(hrefs).not.toContain("/clients");
+    expect(hrefs).not.toContain("/playbook");
+    expect(hrefs).not.toContain("/admin/users");
+  });
+});
+
+describe("getNavItems — coach role", () => {
+  it("includes user + coach items", () => {
+    const items = getNavItems("coach", false);
+    const hrefs = items.map((i) => i.href);
+    expect(hrefs).toContain("/dashboard");
+    expect(hrefs).toContain("/clients");
+    expect(hrefs).toContain("/playbook");
+  });
+
+  it("excludes admin items", () => {
+    const items = getNavItems("coach", false);
+    const hrefs = items.map((i) => i.href);
+    expect(hrefs).not.toContain("/admin/users");
+    expect(hrefs).not.toContain("/admin/programs");
+  });
+});
+
+describe("getNavItems — admin role", () => {
+  it("includes all nav items", () => {
+    const items = getNavItems("admin", false);
+    const hrefs = items.map((i) => i.href);
+    expect(hrefs).toContain("/dashboard");
+    expect(hrefs).toContain("/clients");
+    expect(hrefs).toContain("/playbook");
+    expect(hrefs).toContain("/admin/users");
+    expect(hrefs).toContain("/admin/programs");
+  });
+});
+
+describe("needsOnboarding", () => {
+  it("returns true when onboarding_done is false", () => {
+    expect(needsOnboarding(false)).toBe(true);
+  });
+
+  it("returns false when onboarding_done is true", () => {
+    expect(needsOnboarding(true)).toBe(false);
+  });
+});

--- a/tests/rbac.test.ts
+++ b/tests/rbac.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import { getRequiredRole, canAccess, isRouteAllowed } from "@/lib/rbac";
+
+describe("getRequiredRole", () => {
+  it("returns null for /dashboard", () => {
+    expect(getRequiredRole("/dashboard")).toBeNull();
+  });
+
+  it("returns null for /sessions", () => {
+    expect(getRequiredRole("/sessions")).toBeNull();
+  });
+
+  it("returns null for /progress", () => {
+    expect(getRequiredRole("/progress")).toBeNull();
+  });
+
+  it("returns null for /coach-notes", () => {
+    expect(getRequiredRole("/coach-notes")).toBeNull();
+  });
+
+  it("returns 'coach' for /clients", () => {
+    expect(getRequiredRole("/clients")).toBe("coach");
+  });
+
+  it("returns 'coach' for /clients/some-id", () => {
+    expect(getRequiredRole("/clients/abc-123")).toBe("coach");
+  });
+
+  it("returns 'coach' for /playbook", () => {
+    expect(getRequiredRole("/playbook")).toBe("coach");
+  });
+
+  it("returns 'admin' for /admin", () => {
+    expect(getRequiredRole("/admin")).toBe("admin");
+  });
+
+  it("returns 'admin' for /admin/users", () => {
+    expect(getRequiredRole("/admin/users")).toBe("admin");
+  });
+
+  it("returns 'admin' for /admin/programs", () => {
+    expect(getRequiredRole("/admin/programs")).toBe("admin");
+  });
+});
+
+describe("canAccess", () => {
+  it("admin can access admin routes", () => {
+    expect(canAccess("admin", "admin")).toBe(true);
+  });
+
+  it("admin can access coach routes", () => {
+    expect(canAccess("admin", "coach")).toBe(true);
+  });
+
+  it("coach can access coach routes", () => {
+    expect(canAccess("coach", "coach")).toBe(true);
+  });
+
+  it("coach cannot access admin routes", () => {
+    expect(canAccess("coach", "admin")).toBe(false);
+  });
+
+  it("user cannot access coach routes", () => {
+    expect(canAccess("user", "coach")).toBe(false);
+  });
+
+  it("user cannot access admin routes", () => {
+    expect(canAccess("user", "admin")).toBe(false);
+  });
+});
+
+describe("isRouteAllowed", () => {
+  it("allows user on /dashboard", () => {
+    expect(isRouteAllowed("/dashboard", "user")).toBe(true);
+  });
+
+  it("allows user on /sessions", () => {
+    expect(isRouteAllowed("/sessions", "user")).toBe(true);
+  });
+
+  it("blocks user on /clients", () => {
+    expect(isRouteAllowed("/clients", "user")).toBe(false);
+  });
+
+  it("blocks user on /admin/users", () => {
+    expect(isRouteAllowed("/admin/users", "user")).toBe(false);
+  });
+
+  it("allows coach on /clients", () => {
+    expect(isRouteAllowed("/clients", "coach")).toBe(true);
+  });
+
+  it("allows coach on /playbook", () => {
+    expect(isRouteAllowed("/playbook", "coach")).toBe(true);
+  });
+
+  it("blocks coach on /admin/users", () => {
+    expect(isRouteAllowed("/admin/users", "coach")).toBe(false);
+  });
+
+  it("allows admin on /admin/users", () => {
+    expect(isRouteAllowed("/admin/users", "admin")).toBe(true);
+  });
+
+  it("allows admin on /clients", () => {
+    expect(isRouteAllowed("/clients", "admin")).toBe(true);
+  });
+
+  it("allows admin on /dashboard", () => {
+    expect(isRouteAllowed("/dashboard", "admin")).toBe(true);
+  });
+});

--- a/tests/seed-validation.test.ts
+++ b/tests/seed-validation.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from "vitest";
+import {
+  validatePhasesCover12Weeks,
+  validateSessionCount,
+  validateSessionsPerWeek,
+  validateWeightDefaults,
+  validateMaleGeqFemale,
+  validateSetsReps,
+  type SeedPhase,
+  type SeedSession,
+  type SeedExercise,
+} from "@/lib/seed-validation";
+
+// ── Canonical seed data matching supabase/seed.sql ──────────────────────────
+
+const PHASES: SeedPhase[] = [
+  { phase_number: 1, week_start: 1,  week_end: 4,  name: "Foundation" },
+  { phase_number: 2, week_start: 5,  week_end: 8,  name: "Load Introduction" },
+  { phase_number: 3, week_start: 9,  week_end: 12, name: "Strength" },
+];
+
+function buildSessions(): SeedSession[] {
+  const sessions: SeedSession[] = [];
+  let sessionNumber = 1;
+  const phaseMap: Record<number, number> = { 1: 1, 2: 1, 3: 1, 4: 1, 5: 2, 6: 2, 7: 2, 8: 2, 9: 3, 10: 3, 11: 3, 12: 3 };
+  for (let week = 1; week <= 12; week++) {
+    for (const label of ["A", "B", "C"] as const) {
+      sessions.push({
+        week_number: week,
+        session_number: sessionNumber++,
+        day_label: label,
+        phase_number: phaseMap[week],
+      });
+    }
+  }
+  return sessions;
+}
+
+const SESSIONS = buildSessions();
+
+const VALID_WEIGHTED_EXERCISE: SeedExercise = {
+  is_bodyweight: false,
+  weight_pre_baseline_f: 45,
+  weight_pre_baseline_m: 65,
+  weight_default_f: 65,
+  weight_default_m: 95,
+  weight_post_baseline_f: 95,
+  weight_post_baseline_m: 135,
+  is_abs_finisher: false,
+  sets_default: 3,
+  reps_default: 8,
+};
+
+const BODYWEIGHT_EXERCISE: SeedExercise = {
+  is_bodyweight: true,
+  weight_pre_baseline_f: 0,
+  weight_pre_baseline_m: 0,
+  weight_default_f: 0,
+  weight_default_m: 0,
+  weight_post_baseline_f: 0,
+  weight_post_baseline_m: 0,
+  is_abs_finisher: false,
+  sets_default: 2,
+  reps_default: 15,
+};
+
+// ── Phase structure ──────────────────────────────────────────────────────────
+
+describe("validatePhasesCover12Weeks", () => {
+  it("passes for canonical 3-phase 12-week structure", () => {
+    expect(validatePhasesCover12Weeks(PHASES)).toBe(true);
+  });
+
+  it("fails if fewer than 3 phases", () => {
+    expect(validatePhasesCover12Weeks(PHASES.slice(0, 2))).toBe(false);
+  });
+
+  it("fails if week_start does not begin at 1", () => {
+    const bad = [
+      { ...PHASES[0], week_start: 2 },
+      PHASES[1],
+      PHASES[2],
+    ];
+    expect(validatePhasesCover12Weeks(bad)).toBe(false);
+  });
+
+  it("fails if week_end does not reach 12", () => {
+    const bad = [
+      PHASES[0],
+      PHASES[1],
+      { ...PHASES[2], week_end: 11 },
+    ];
+    expect(validatePhasesCover12Weeks(bad)).toBe(false);
+  });
+
+  it("fails if there is a gap between phases", () => {
+    const bad = [
+      { ...PHASES[0], week_end: 3 },  // ends week 3
+      { ...PHASES[1], week_start: 5 }, // starts week 5 — gap at week 4
+      PHASES[2],
+    ];
+    expect(validatePhasesCover12Weeks(bad)).toBe(false);
+  });
+});
+
+// ── Session count ────────────────────────────────────────────────────────────
+
+describe("validateSessionCount", () => {
+  it("passes for 36 sessions", () => {
+    expect(validateSessionCount(SESSIONS)).toBe(true);
+  });
+
+  it("fails for fewer than 36 sessions", () => {
+    expect(validateSessionCount(SESSIONS.slice(0, 35))).toBe(false);
+  });
+
+  it("fails for more than 36 sessions", () => {
+    expect(validateSessionCount([...SESSIONS, SESSIONS[0]])).toBe(false);
+  });
+});
+
+// ── Sessions per week ────────────────────────────────────────────────────────
+
+describe("validateSessionsPerWeek", () => {
+  it("passes for canonical 12-week × 3-session-per-week structure", () => {
+    expect(validateSessionsPerWeek(SESSIONS)).toBe(true);
+  });
+
+  it("fails if a week is missing the C day", () => {
+    const bad = SESSIONS.filter((s) => !(s.week_number === 3 && s.day_label === "C"));
+    expect(validateSessionsPerWeek(bad)).toBe(false);
+  });
+
+  it("fails if a week has a duplicate day", () => {
+    const extraA = { week_number: 1, session_number: 999, day_label: "A" as const, phase_number: 1 };
+    const bad = SESSIONS.filter((s) => !(s.week_number === 1 && s.day_label === "C"));
+    bad.push(extraA);
+    expect(validateSessionsPerWeek(bad)).toBe(false);
+  });
+});
+
+// ── Exercise weight defaults ─────────────────────────────────────────────────
+
+describe("validateWeightDefaults", () => {
+  it("passes for valid weighted exercise", () => {
+    expect(validateWeightDefaults(VALID_WEIGHTED_EXERCISE)).toBe(true);
+  });
+
+  it("passes for bodyweight exercise (all zeros)", () => {
+    expect(validateWeightDefaults(BODYWEIGHT_EXERCISE)).toBe(true);
+  });
+
+  it("fails if any weight is negative", () => {
+    expect(validateWeightDefaults({ ...VALID_WEIGHTED_EXERCISE, weight_default_f: -5 })).toBe(false);
+  });
+});
+
+describe("validateMaleGeqFemale", () => {
+  it("passes when male >= female for all tiers", () => {
+    expect(validateMaleGeqFemale(VALID_WEIGHTED_EXERCISE)).toBe(true);
+  });
+
+  it("passes for bodyweight exercise", () => {
+    expect(validateMaleGeqFemale(BODYWEIGHT_EXERCISE)).toBe(true);
+  });
+
+  it("fails when male default < female default", () => {
+    expect(validateMaleGeqFemale({ ...VALID_WEIGHTED_EXERCISE, weight_default_m: 50, weight_default_f: 65 })).toBe(false);
+  });
+});
+
+describe("validateSetsReps", () => {
+  it("passes for standard 3×8", () => {
+    expect(validateSetsReps(VALID_WEIGHTED_EXERCISE)).toBe(true);
+  });
+
+  it("passes for time-based exercise (reps=0)", () => {
+    expect(validateSetsReps({ ...BODYWEIGHT_EXERCISE, reps_default: 0 })).toBe(true);
+  });
+
+  it("fails for 0 sets", () => {
+    expect(validateSetsReps({ ...VALID_WEIGHTED_EXERCISE, sets_default: 0 })).toBe(false);
+  });
+
+  it("fails for reps over 20", () => {
+    expect(validateSetsReps({ ...VALID_WEIGHTED_EXERCISE, reps_default: 25 })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Context
PRs #8, #9, #10 showed as merged in GitHub but their commits never landed on \`main\` (stacked PR merge artifact). This PR brings all three missing pieces at once from \`feat/batch-1-seed\`, which contains the full chain.

## Commits included
1. **RBAC** (was PR #8) — \`lib/rbac.ts\`, role guard in \`proxy.ts\`, 26 rbac tests
2. **Profile shell** (was PR #9) — server app layout, role-aware Sidebar, Header w/ sign-out, onboarding redirect, 9 profile tests
3. **Seed** (was PR #10) — \`supabase/seed.sql\` (3 phases, 36 sessions, 32 exercises), seed-validation helpers, 21 seed tests
4. **Monitor fix** — \`/api/monitor/\` added to public routes in \`proxy.ts\` so PIN submit no longer gets a 405

**PR #11 can be closed as redundant** — this PR includes the same fix.

## Test plan
- [x] \`pnpm test\` — 103 tests pass across all 6 test files
- [x] \`pnpm tsc --noEmit\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)