### PR TITLE
feat: GitHub Issue per roadmap item — created at kickoff, closed on PR merge

### DIFF
--- a/.github/workflows/claude-feature.yml
+++ b/.github/workflows/claude-feature.yml
@@ -19,6 +19,11 @@ on:
         description: "Branch name to create (e.g. feat/batch-1-auth)"
         required: true
         type: string
+      issue_number:
+        description: "GitHub Issue number tracking this item (e.g. 13)"
+        required: false
+        default: ""
+        type: string
       retry:
         description: "Is this a retry run?"
         required: false
@@ -31,6 +36,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      issues: write
 
     steps:
       - name: Checkout
@@ -66,6 +72,7 @@ jobs:
             **Item:** ${{ inputs.item_title }}
             **Description:** ${{ inputs.item_description }}
             **Branch:** ${{ inputs.branch_name }}
+            ${{ inputs.issue_number != '' && format('**GitHub Issue:** #{0} — read it for full context and implementation notes.', inputs.issue_number) || '' }}
 
             Read CLAUDE.md first for full project context, conventions, and architecture.
             Read WIKI/index.md for current project status.
@@ -78,8 +85,9 @@ jobs:
             4. Run `pnpm test` and fix all failing tests
             5. If the description above contains a FILE SCOPE CONTRACT section, you are running in
                parallel with other agents. In that case, do NOT modify lib/roadmap-data.ts —
-               the kickoff system manages status. Otherwise, set status to "in-progress" for
-               item ${{ inputs.item_id }} in lib/roadmap-data.ts.
+               the kickoff system manages status. Otherwise, set status to "in-progress" and
+               pr to the PR number for item ${{ inputs.item_id }} in lib/roadmap-data.ts.
+               ${{ inputs.issue_number != '' && format('Also set issue to {0} in lib/roadmap-data.ts for this item.', inputs.issue_number) || '' }}
 
             Do NOT push or create a PR — the workflow handles that.
 
@@ -98,6 +106,7 @@ jobs:
           git push origin "${{ inputs.branch_name }}"
 
       - name: Create Pull Request
+        id: create_pr
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -110,6 +119,8 @@ jobs:
             **${{ inputs.item_title }}**
 
             ${{ inputs.item_description }}
+
+            ${{ inputs.issue_number != '' && format('Closes #{0}', inputs.issue_number) || '' }}
 
             ---
             🤖 Implemented by [Claude Code](https://claude.ai/claude-code) via workflow dispatch.

--- a/app/api/monitor/kickoff/route.ts
+++ b/app/api/monitor/kickoff/route.ts
@@ -2,6 +2,64 @@ import { NextResponse } from "next/server";
 import { ROADMAP, REPO } from "@/lib/roadmap-data";
 import { MONITOR_COOKIE } from "@/lib/constants";
 
+const GH_API = "https://api.github.com";
+
+function ghHeaders(token: string) {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "Content-Type": "application/json",
+  };
+}
+
+/** Creates a GitHub Issue for a roadmap item. Returns the issue number, or null on failure. */
+async function createIssue(
+  token: string,
+  item: { id: string; title: string; description: string; branch?: string; scope?: { owns: string[]; avoid: string[] } }
+): Promise<number | null> {
+  const scopeSection = item.scope
+    ? `\n### File Scope\n- **Owns:** ${item.scope.owns.map((p) => `\`${p}\``).join(", ")}\n- **Avoid:** ${item.scope.avoid.map((p) => `\`${p}\``).join(", ")}`
+    : "";
+
+  const body = [
+    `## BuildBase Roadmap Item \`${item.id}\``,
+    "",
+    `**${item.title}**`,
+    "",
+    item.description,
+    "",
+    "---",
+    "",
+    "### Implementation Notes",
+    `- Branch: \`${item.branch ?? `feat/item-${item.id}`}\``,
+    scopeSection,
+    "",
+    "### Agent References",
+    `- [\`CLAUDE.md\`](https://github.com/${REPO}/blob/main/CLAUDE.md) — project conventions, architecture, design tokens`,
+    `- [\`WIKI/index.md\`](https://github.com/${REPO}/blob/main/WIKI/index.md) — current status, file map`,
+    `- [\`WIKI/gotchas.md\`](https://github.com/${REPO}/blob/main/WIKI/gotchas.md) — known pitfalls, read first`,
+    "",
+    "---",
+    "*Opened automatically by the BuildBase roadmap monitor at kickoff.*",
+  ]
+    .filter((line) => line !== undefined)
+    .join("\n");
+
+  const res = await fetch(`${GH_API}/repos/${REPO}/issues`, {
+    method: "POST",
+    headers: ghHeaders(token),
+    body: JSON.stringify({ title: `[${item.id}] ${item.title}`, body }),
+  });
+
+  if (!res.ok) {
+    console.error("Failed to create issue:", res.status, await res.text());
+    return null;
+  }
+
+  const data = await res.json() as { number: number };
+  return data.number;
+}
+
 export async function POST(request: Request) {
   // Verify monitor session
   const cookie = request.headers.get("cookie") ?? "";
@@ -27,16 +85,15 @@ export async function POST(request: Request) {
     return NextResponse.json({ success: false, error: "GITHUB_TOKEN not configured" }, { status: 500 });
   }
 
+  // Create a GitHub Issue for this item (best-effort — dispatch proceeds even if this fails)
+  const issueNumber = await createIssue(token, item);
+
   // Trigger workflow_dispatch on GitHub Actions
   const res = await fetch(
-    `https://api.github.com/repos/${REPO}/actions/workflows/claude-feature.yml/dispatches`,
+    `${GH_API}/repos/${REPO}/actions/workflows/claude-feature.yml/dispatches`,
     {
       method: "POST",
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: "application/vnd.github+json",
-        "Content-Type": "application/json",
-      },
+      headers: ghHeaders(token),
       body: JSON.stringify({
         ref: "main",
         inputs: {
@@ -44,6 +101,7 @@ export async function POST(request: Request) {
           item_title: item.title,
           item_description: item.description,
           branch_name: item.branch ?? `feat/item-${itemId}`,
+          issue_number: issueNumber != null ? String(issueNumber) : "",
           retry: retry ? "true" : "false",
         },
       }),
@@ -58,6 +116,8 @@ export async function POST(request: Request) {
 
   return NextResponse.json({
     success: true,
+    issueNumber,
+    issueUrl: issueNumber != null ? `https://github.com/${REPO}/issues/${issueNumber}` : null,
     prUrl: null, // PR URL will be available once CI creates it
   });
 }

--- a/app/monitor/roadmap/page.tsx
+++ b/app/monitor/roadmap/page.tsx
@@ -136,6 +136,12 @@ function ItemRow({ item, prData }: { item: RoadmapItem; prData: Awaited<ReturnTy
           <RetryButton itemId={item.id} />
         )}
 
+        {item.issue && (
+          <a href={`https://github.com/${REPO}/issues/${item.issue}`} target="_blank" rel="noopener"
+            style={{ fontSize: 11, color: "#8A9E8A", textDecoration: "none", background: "rgba(138,158,138,0.08)", border: "1px solid rgba(138,158,138,0.2)", borderRadius: 6, padding: "2px 8px" }}>
+            #{item.issue}
+          </a>
+        )}
         {item.pr && (
           <a href={`https://github.com/${REPO}/pull/${item.pr}`} target="_blank" rel="noopener"
             style={{ fontSize: 11, color: "#3060A0", textDecoration: "none", background: "rgba(48,96,160,0.08)", border: "1px solid rgba(48,96,160,0.2)", borderRadius: 6, padding: "2px 8px" }}>

--- a/lib/roadmap-data.ts
+++ b/lib/roadmap-data.ts
@@ -14,6 +14,8 @@ export interface RoadmapItem {
   tests: boolean;
   branch?: string;
   pr?: number;
+  /** GitHub Issue number created at kickoff time. Closed automatically when PR merges. */
+  issue?: number;
   /** File scope contract for parallel agent execution. */
   scope?: ItemScope;
 }


### PR DESCRIPTION
## Summary
- `app/api/monitor/kickoff/route.ts` — creates a GitHub Issue before dispatching the workflow; passes `issue_number` to the dispatch inputs; returns `issueUrl` in the response
- `.github/workflows/claude-feature.yml` — adds `issue_number` optional input; injects it into the Claude prompt ("read issue #N for context") and PR body (`Closes #N`); adds `issues: write` permission
- `lib/roadmap-data.ts` — adds `issue?: number` field to `RoadmapItem`
- `app/monitor/roadmap/page.tsx` — renders issue badge (`#N` → GitHub Issues link) alongside the existing PR badge

## Flow
```
Monitor "Start" click
  → POST /api/monitor/kickoff
      → Create GitHub Issue [item-id] title + rich context body
      → workflow_dispatch(issue_number, item_id, ...)
          → Claude reads issue for context
          → Implements feature
          → PR body: "Closes #N"
              → PR merge auto-closes the issue
```

## Issue body includes
- Item ID, title, description
- Branch name
- File scope (owns/avoid) if present
- Links to CLAUDE.md, WIKI/index.md, WIKI/gotchas.md

## Notes
- Issue creation is best-effort: if it fails, the workflow dispatch still proceeds (no issue number passed)
- `issue_number` is optional in the workflow so manual `workflow_dispatch` from GitHub UI still works without it

🤖 Generated with [Claude Code](https://claude.com/claude-code)