### PR TITLE
fix: workflow id-token, pulsing kickoff dot, branch guard

### DIFF
--- a/.github/workflows/claude-feature.yml
+++ b/.github/workflows/claude-feature.yml
@@ -42,6 +42,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      id-token: write
 
     steps:
       - name: Checkout feature branch

--- a/app/api/monitor/kickoff-batch/route.ts
+++ b/app/api/monitor/kickoff-batch/route.ts
@@ -66,7 +66,11 @@ export async function POST(request: Request) {
 
       // Branch + initial commit
       if (mainSha) {
-        await ensureBranchReady(token, REPO, branchName, mainSha, item.id, item.title);
+        const branchReady = await ensureBranchReady(token, REPO, branchName, mainSha, item.id, item.title);
+        if (!branchReady) {
+          console.error(`[kickoff-batch] ensureBranchReady failed for ${branchName}`);
+          return { itemId: item.id, success: false, error: "Failed to prepare branch — check GITHUB_TOKEN permissions" };
+        }
       }
 
       // Draft PR — reuse if already exists

--- a/app/api/monitor/kickoff/route.ts
+++ b/app/api/monitor/kickoff/route.ts
@@ -42,7 +42,14 @@ export async function POST(request: Request) {
   // 2. Branch + initial commit — ensures PR creation won't fail with "no commits between branches"
   const mainSha = await getMainSha(token, REPO);
   if (mainSha) {
-    await ensureBranchReady(token, REPO, branchName, mainSha, itemId, item.title);
+    const branchReady = await ensureBranchReady(token, REPO, branchName, mainSha, itemId, item.title);
+    if (!branchReady) {
+      console.error(`[kickoff] ensureBranchReady failed for ${branchName}`);
+      return NextResponse.json(
+        { success: false, error: "Failed to prepare branch — check GITHUB_TOKEN permissions" },
+        { status: 502 }
+      );
+    }
   }
 
   // 3. Draft PR — reuses existing if one is already open for this branch

--- a/app/monitor/roadmap/KickoffButton.tsx
+++ b/app/monitor/roadmap/KickoffButton.tsx
@@ -2,6 +2,26 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { motion } from "framer-motion";
+
+function PulsingDot({ color }: { color: string }) {
+  return (
+    <motion.span
+      animate={{ opacity: [1, 0.25, 1], scale: [1, 1.4, 1] }}
+      transition={{ duration: 1.4, ease: "easeInOut", repeat: Infinity }}
+      style={{
+        display: "inline-block",
+        width: 7,
+        height: 7,
+        borderRadius: "50%",
+        background: color,
+        marginRight: 5,
+        verticalAlign: "middle",
+        flexShrink: 0,
+      }}
+    />
+  );
+}
 
 export function KickoffButton({ itemId, disabled }: { itemId: string; disabled: boolean }) {
   const [state, setState] = useState<"idle" | "loading" | "done" | "error">("idle");
@@ -23,7 +43,7 @@ export function KickoffButton({ itemId, disabled }: { itemId: string; disabled: 
       if (!res.ok || !data.success) throw new Error(data.error ?? "Kickoff failed");
       setPrUrl(data.prUrl ?? null);
       setState("done");
-      // Refresh after a short delay so KV override shows in-progress
+      // Refresh after short delay so KV override shows in-progress
       setTimeout(() => router.refresh(), 800);
     } catch (err) {
       console.error(err);
@@ -39,28 +59,48 @@ export function KickoffButton({ itemId, disabled }: { itemId: string; disabled: 
         target="_blank"
         rel="noopener"
         style={{
+          display: "inline-flex",
+          alignItems: "center",
           fontSize: 11, fontWeight: 700, color: "#3060A0",
           background: "rgba(48,96,160,0.1)", border: "1px solid rgba(48,96,160,0.3)",
           borderRadius: 6, padding: "3px 10px", textDecoration: "none",
           pointerEvents: prUrl ? "auto" : "none",
         }}>
-        ✓ Started{prUrl ? " → PR" : ""}
+        <PulsingDot color="#3060A0" />
+        Started{prUrl ? " → PR" : ""}
       </a>
     );
   }
 
+  if (state === "loading") {
+    return (
+      <span
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          fontSize: 11, fontWeight: 700, color: "#C84B1A",
+          background: "rgba(200,75,26,0.08)", border: "1px solid rgba(200,75,26,0.25)",
+          borderRadius: 6, padding: "3px 10px",
+        }}>
+        <PulsingDot color="#C84B1A" />
+        Starting…
+      </span>
+    );
+  }
+
+  const isError = state === "error";
   return (
-    <button onClick={() => void handleStart()} disabled={state === "loading"}
+    <button
+      onClick={() => void handleStart()}
       style={{
         fontSize: 11, fontWeight: 700,
-        color: state === "error" ? "#B83020" : "#C84B1A",
-        background: state === "error" ? "rgba(184,48,32,0.08)" : "rgba(200,75,26,0.08)",
-        border: `1px solid ${state === "error" ? "rgba(184,48,32,0.3)" : "rgba(200,75,26,0.25)"}`,
+        color: isError ? "#B83020" : "#C84B1A",
+        background: isError ? "rgba(184,48,32,0.08)" : "rgba(200,75,26,0.08)",
+        border: `1px solid ${isError ? "rgba(184,48,32,0.3)" : "rgba(200,75,26,0.25)"}`,
         borderRadius: 6, padding: "3px 10px",
-        cursor: state === "loading" ? "not-allowed" : "pointer",
-        opacity: state === "loading" ? 0.6 : 1,
+        cursor: "pointer",
       }}>
-      {state === "loading" ? "Starting…" : state === "error" ? "Failed — retry" : "▶ Start"}
+      {isError ? "Failed — retry" : "▶ Start"}
     </button>
   );
 }


### PR DESCRIPTION
## Summary
- Add `id-token: write` to `claude-feature.yml` permissions — this was the hard failure preventing `claude-code-action@beta` from fetching its OIDC token (Error: "Unable to get ACTIONS_ID_TOKEN_REQUEST_URL")
- `KickoffButton` now renders a Framer Motion pulsing dot immediately on click (orange while loading, blue on done), matching the `[● In Progress] [PR #N]` aesthetic
- Both kickoff routes (`/api/monitor/kickoff` and `/api/monitor/kickoff-batch`) now check the return value of `ensureBranchReady` and surface a 502 error instead of silently continuing with a missing branch

## Test plan
- [ ] Trigger a kickoff and confirm the button shows a pulsing orange dot immediately
- [ ] After dispatch completes, button shows pulsing blue dot + "Started → PR" link
- [ ] Workflow run no longer fails with OIDC token error
- [ ] If `GITHUB_TOKEN` lacks `contents: write`, kickoff returns a 502 instead of silently dispatching to a nonexistent branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)