### PR TITLE
fix(ci): set mode:agent and direct_prompt on claude-code-action

### DIFF
--- a/.github/workflows/claude-feature.yml
+++ b/.github/workflows/claude-feature.yml
@@ -72,7 +72,8 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          prompt: |
+          mode: agent
+          direct_prompt: |
             You are implementing roadmap item ${{ inputs.item_id }} for BuildBase.
 
             **Item:** ${{ inputs.item_title }}


### PR DESCRIPTION
## Summary
The previous merge of #46 resolved a conflict back to the old values. Main still has `prompt:` without `mode: agent`.

Two-line fix:
- `prompt:` → `direct_prompt:` (the correct input name per the action's schema)  
- Add `mode: agent` (required for `workflow_dispatch` events — without it the action throws "Tag mode cannot handle workflow_dispatch events")

## Test plan
- [ ] Merge and trigger a kickoff — the "Run Claude Code" step should proceed past prepare without the mode error

🤖 Generated with [Claude Code](https://claude.com/claude-code)