### PR TITLE
chore: update wiki with session context and all gotchas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,9 @@
 ## Wiki (read before starting any task)
 - **Project wiki:** `WIKI/index.md` — architecture, key files, design tokens, current status
 - **Gotchas:** `WIKI/gotchas.md` — real failures that have happened, read this first
-- **Design doc:** `~/Downloads/ClaudeCode/project-design-docs/BuildBase-design-doc.md` — full product spec
+- **Agent guide:** `WIKI/agents.md` — agent-specific context for GitHub Actions runs
+- **Design system:** `WIKI/design-system.md` — full visual spec and component patterns
+- **Global wiki:** `~/.claude/wiki/index.md` — cross-project context
 
 ---
 

--- a/WIKI/agents.md
+++ b/WIKI/agents.md
@@ -1,46 +1,78 @@
-# BuildBase — Agent Guide
+---
+type: agent-guide
+tags: [agents, buildbase, github-actions]
+last-updated: 2026-04-16
+---
+
+# Agent Guide — BuildBase
+
+> Read this if you are a Claude Code agent running in GitHub Actions via `claude-feature.yml`.
+
+---
 
 ## Your Environment
 
-- **Repo:** `~/Desktop/projects/BuildBase`
-- **Node:** 20+ (pnpm 9)
-- **Next.js:** 16.2.2 — see gotchas.md for breaking changes
-- **TypeScript:** strict mode
+- **Repo:** checked out at the working directory, on the feature branch specified by `inputs.branch_name`
+- **Node:** 20, pnpm 9 — dependencies already installed by the workflow
+- **Git:** configured as `github-actions[bot]` — do NOT run `git add`, `git commit`, or `git push` yourself. The workflow handles all of that after you finish.
+- **Secrets available:** `ANTHROPIC_API_KEY` (your own key, already in use), `GITHUB_TOKEN` (OIDC-provisioned)
 
-## Setup Before Writing Code
+## Workflow Inputs You Receive
 
-```bash
-cd ~/Desktop/projects/BuildBase
-pnpm install
-cp .env.example .env.local
-# Fill in Supabase vars in .env.local
-```
+| Input | What it is |
+|---|---|
+| `item_id` | Roadmap item ID, e.g. `"2-1"` |
+| `item_title` | Short title of the item |
+| `item_description` | Brief description (may include FILE SCOPE CONTRACT for parallel runs) |
+| `branch_name` | Feature branch, already created and checked out |
+| `issue_number` | GitHub Issue # with the full spec — **read this first** |
+| `pr_number` | Draft PR # already open — push commits to it, do NOT create a new PR |
 
-## Required Completion Steps (before every PR)
+## Your Job — Step by Step
 
-```bash
-pnpm tsc --noEmit   # must be clean — zero errors
-pnpm test           # must pass — all tests green
-```
+1. **Read `CLAUDE.md`** — project conventions, design tokens, architecture
+2. **Read `WIKI/gotchas.md`** — real failures. Do this before writing a single line
+3. **Read GitHub Issue `#<issue_number>`** — full implementation spec, acceptance criteria, FILE SCOPE CONTRACT
+4. **Write code** — follow the file scope contract if present (parallel batch runs only)
+5. **Write tests** in `tests/` — see coverage requirements below
+6. **Run `pnpm tsc --noEmit`** — fix every type error before finishing
+7. **Run `pnpm test`** — fix every failing test before finishing
+8. **Update `lib/roadmap-data.ts`** for your item — set `status: "in-progress"`, `pr: <pr_number>`, confirm `issue: <issue_number>` is set
+   - **EXCEPTION:** If the description contains FILE SCOPE CONTRACT, **skip this step** — the kickoff API manages status for parallel agents
 
-Then update `lib/roadmap-data.ts`:
-- Set `status: "in-progress"` for your item when you start
-- Set `status: "done"` and `tests: true` when the PR is ready
+## Critical Constraints
+
+- **Do NOT run git commands** — no `git add`, `git commit`, `git push`. The workflow commits everything after you return.
+- **Do NOT create a new PR** — Draft PR `#<pr_number>` already exists. Pushing commits is enough.
+- **Do NOT modify `lib/roadmap-data.ts`** if you are in a parallel batch (FILE SCOPE CONTRACT present in your description).
+- **Respect FILE SCOPE CONTRACT** — if the issue lists "Owns" and "Avoid" paths, only touch files under "Owns".
 
 ## Test Requirements
 
-Every batch item needs tests in `tests/` before its PR merges.
+Tests live in `tests/`. Coverage target: `lib/**/*.ts` (excludes external API wrappers).
 
-Minimum coverage per item:
-- **Batch 1 (auth/RBAC):** Test that unauthenticated users are redirected, role checks work
-- **Batch 2 (session tracker):** Test `getDefaultWeight()`, `hoursSince()`, soreness prompt trigger logic
-- **Batch 3 (phase view):** Test session status calculations (complete/current/upcoming)
-- **Batch 4 (coach features):** Test `getFormBadge()` — ensure it NEVER returns raw form status to user
-- **Batch 5 (admin):** Test role validation, override application
-- **Batch 6 (metrics):** Test PR detection logic, streak calculation
-- **Batches 7–8:** Test utility functions and API route response shapes
+Minimum per batch:
 
-Coverage target: `lib/**/*.ts` (excludes external API wrappers)
+| Batch | What to test |
+|---|---|
+| 1 — Auth/RBAC | Unauthenticated redirect, role checks, profile creation logic |
+| 2 — Session Tracker | `getDefaultWeight()`, `hoursSince()`, soreness prompt trigger |
+| 3 — Phase View | Session status calculations (complete/current/upcoming) |
+| 4 — Coach Features | `getFormBadge()` — must never return raw form status to user role |
+| 5 — Admin | Role validation, override application |
+| 6 — Metrics | PR detection logic, streak calculation |
+| 7 — Template Editor | API route response shapes, validation |
+
+## Required Workflow Permissions
+
+The workflow (`claude-feature.yml`) runs with:
+```yaml
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write    # Required for OIDC token used by claude-code-action@beta
+```
 
 ## Key Imports
 
@@ -49,69 +81,53 @@ Coverage target: `lib/**/*.ts` (excludes external API wrappers)
 import type { Profile, SessionLog, SetLog, CoachNote } from "@/lib/types";
 
 // Supabase — pick the right one
-import { createClient } from "@/lib/supabase/server";  // Server Components
-import { createClient } from "@/lib/supabase/client";  // Client Components
+import { createClient } from "@/lib/supabase/server";  // Server Components, Route Handlers
+import { createClient } from "@/lib/supabase/client";  // Client Components only
 
 // Utils
 import { cn, getFormBadge, getDefaultWeight, formatWeight, hoursSince } from "@/lib/utils";
 
 // Constants
 import { EFFORT_LABELS, SORENESS_LABELS, SESSIONS_PER_PAGE, SORENESS_PROMPT_GAP_HOURS } from "@/lib/constants";
+
+// RBAC
+import { hasRole, requireRole } from "@/lib/rbac";
 ```
 
-## Supabase Query Patterns
+## Common Supabase Patterns
 
 ```ts
 // Server Component — get current user
 const supabase = await createClient();
 const { data: { user } } = await supabase.auth.getUser();
+if (!user) redirect("/login");
 
-// Server Component — get profile with coach check
+// Get profile
 const { data: profile } = await supabase
   .from("profiles")
   .select("*")
   .eq("id", user.id)
   .single();
 
-// Never query coach_form_assessments in user-facing components
-// Use getFormBadge() instead — it returns "Solid Form ✅" or null
+// NEVER query coach_form_assessments in user-facing components — use getFormBadge() instead
 ```
 
-## Component Patterns
+## What NOT To Do
 
-```tsx
-// Server Component with auth check
-import { createClient } from "@/lib/supabase/server";
-import { redirect } from "next/navigation";
-
-export default async function ProtectedPage() {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) redirect("/login");
-  // ...
-}
-
-// Client Component with optimistic update
-"use client";
-import { useState } from "react";
-import { createClient } from "@/lib/supabase/client";
-
-export function SetRow({ setLog, ... }) {
-  const [completed, setCompleted] = useState(setLog.is_completed);
-  
-  async function toggleSet() {
-    setCompleted(true); // optimistic
-    const supabase = createClient();
-    await supabase.from("set_logs").update({ is_completed: true }).eq("id", setLog.id);
-  }
-  // ...
-}
-```
+- ❌ `git commit` / `git push` / `git add` — workflow handles this
+- ❌ Create a new PR — the draft PR already exists
+- ❌ Modify `lib/roadmap-data.ts` during parallel batch runs
+- ❌ Expose `coach_form_assessments.status` to user-role views
+- ❌ Use `middleware.ts` — it's `proxy.ts` in Next.js 16
+- ❌ Access `params.id` synchronously — always `await params` in Next.js 16
+- ❌ Call `cookies()` synchronously — always `await cookies()`
+- ❌ Create `tailwind.config.ts` — Tailwind v4 is CSS-first, tokens live in `globals.css`
+- ❌ Use `runtime` key in `proxy.ts` config — causes build error
 
 ## Adding shadcn Components
 
 ```bash
-npx shadcn@latest add button card input label dialog sheet badge tabs
+npx shadcn@latest add button card input label dialog sheet badge tabs separator
 ```
 
 Components go to `components/ui/`. Check what's already there before adding.

--- a/WIKI/gotchas.md
+++ b/WIKI/gotchas.md
@@ -1,102 +1,197 @@
-# BuildBase — Gotchas
+---
+type: gotchas
+tags: [gotchas, lessons-learned, buildbase]
+last-updated: 2026-04-16
+---
 
-Real failures and non-obvious pitfalls. Read before writing any code.
+# Gotchas — BuildBase
 
-## Next.js 16
+> Read this before starting any task. Each entry is a real thing that burned us.
+> Add new entries at the top with the date.
 
-### proxy.ts — no `runtime` config key allowed
+---
 
-Next.js 16 proxy always runs on Node.js. Declaring `runtime` in the config export throws a Vercel build error:
-`Route segment config is not allowed in Proxy file. Proxy always runs on Node.js runtime.`
+## 2026-04-16 — claude-code-action@beta requires `mode: agent` + `direct_prompt`
 
-```ts
-// WRONG — build error
-export const config = { runtime: "nodejs", matcher: [...] };
+**Symptom:** Workflow run fails immediately with:
+`Error: Prepare step failed with error: Tag mode cannot handle workflow_dispatch events. Use 'agent' mode for automation events.`
 
-// CORRECT
-export const config = { matcher: [...] };
+**Cause:** `claude-code-action@beta` changed its API. The old input `prompt:` is no longer valid — it must be `direct_prompt:`. And `workflow_dispatch` events require `mode: agent` to be set explicitly (default mode is "tag" which only works on PR/issue events).
+
+**Fix:**
+```yaml
+- uses: anthropics/claude-code-action@beta
+  with:
+    anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+    mode: agent          # ← required for workflow_dispatch
+    direct_prompt: |     # ← not "prompt:"
+      ...
 ```
 
-### proxy.ts — not middleware.ts
-Next.js 16 renamed `middleware.ts` to `proxy.ts`. The exported function must be named `proxy` (not `middleware`). The file already exists at the root — **do not create a new `middleware.ts`**.
+---
 
+## 2026-04-16 — ANTHROPIC_API_KEY must be in GitHub Actions secrets (not just Vercel)
+
+**Symptom:** After fixing the mode error, workflow fails with:
+`Error: Environment variable validation failed: Either ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is required when using direct Anthropic API.`
+
+**Cause:** `ANTHROPIC_API_KEY` is set as a Vercel env var (for any future server-side AI use) but GitHub Actions has its own separate secrets store. The workflow's `secrets.ANTHROPIC_API_KEY` looks in the repo's Actions secrets, not Vercel.
+
+**Fix:** Go to GitHub → repo → Settings → Secrets and variables → Actions → New repository secret → `ANTHROPIC_API_KEY`.
+
+---
+
+## 2026-04-16 — GitHub workflow file: merge conflicts silently drop critical lines
+
+**Symptom:** PR was merged, but `mode: agent` and `direct_prompt:` still weren't on main. The old `prompt:` key survived.
+
+**Cause:** When multiple PRs touched `.github/workflows/claude-feature.yml`, the merge conflict was resolved back to the old version. GitHub's merge commit silently kept the old field names.
+
+**Fix:** After any PR touching `claude-feature.yml`, always verify with `git show origin/main:.github/workflows/claude-feature.yml | grep -E "mode:|direct_prompt:|prompt:"` before triggering a kickoff.
+
+---
+
+## 2026-04-16 — Issue numbers must be stamped in roadmap-data.ts before kickoff
+
+**Symptom:** Clicking "Start" creates a new duplicate GitHub Issue every time, even when the issue already exists.
+
+**Cause:** `createIssue()` is guarded by `item.issue ?? existing?.issue ?? null`. If `item.issue` is `undefined` in `roadmap-data.ts` AND Upstash Redis is not configured (so `existing` is always `{}`), the guard fails and a new issue is created unconditionally on every click.
+
+**Fix:** All issue numbers are now stamped in `lib/roadmap-data.ts` (items 1-1 through 7-3 → GitHub issues #17–40). Never remove these numbers. Duplicate issues #42–44, #47 were closed.
+
+---
+
+## 2026-04-16 — Workflow commit step silently succeeds with 0 changes
+
+**Symptom:** PR is marked "ready for review" but has 0 file changes — only the empty init commit.
+
+**Cause:** The commit step had `|| echo "Nothing to commit"` which swallowed the git failure. Then `git push` pushed the empty branch and `gh pr ready` marked it done. The Claude Code agent may have written nothing (model/auth issue) but the workflow appeared to succeed.
+
+**Fix:** Added a "Verify changes exist" step before commit:
+```bash
+git add -A
+if git diff --cached --quiet; then
+  echo "::error::Claude Code produced no file changes."
+  exit 1
+fi
+```
+
+---
+
+## 2026-04-15 — GitHub fine-grained PAT needs 4 specific permissions
+
+**Symptom:** `/api/monitor/kickoff` returns `{ "error": "Failed to prepare branch — check GITHUB_TOKEN permissions" }`.
+
+**Cause:** The fine-grained PAT used as `GITHUB_TOKEN` in Vercel was missing one or more required permissions.
+
+**Required permissions (all must be Read and write):**
+- **Contents** — create branches, create commits via git data API
+- **Pull requests** — create draft PRs
+- **Issues** — create/read GitHub Issues
+- **Actions** — trigger `workflow_dispatch`
+
+---
+
+## 2026-04-15 — Branch must have ≥1 commit ahead of main for PR creation
+
+**Symptom:** `createDraftPr()` returns 422 from GitHub: "No commits between main and feat/...".
+
+**Cause:** GitHub requires the head branch to have at least one commit that main doesn't have before a PR can be created. `createBranch()` alone just creates a ref pointing to the same SHA as main — same tree, no diff.
+
+**Fix:** `ensureBranchReady()` in `lib/github-api.ts` calls `createEmptyCommit()` when the branch HEAD SHA equals main's HEAD SHA. This creates a git commit with the same tree but a new hash, satisfying GitHub's requirement.
+
+---
+
+## 2026-04-15 — Upstash Redis env vars required for live in-progress status
+
+**Symptom:** Clicking "Start" fires the kickoff API, button shows "Started → PR", but the roadmap page never updates to show "In Progress" after `router.refresh()`.
+
+**Cause:** `setRoadmapOverride()` in `lib/storage.ts` silently no-ops if `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN` are not set. The KV write is skipped, so on the next page render the static `roadmap-data.ts` status (not-started) is still shown.
+
+**Fix:** Set both Upstash env vars in Vercel. The monitor degrades gracefully without them but live status updates don't work.
+
+---
+
+## Next.js 16 — proxy.ts replaces middleware.ts
+
+**Symptom:** Auth guard or session refresh logic silently does nothing.
+
+**Cause:** Next.js 16 renamed `middleware.ts` → `proxy.ts`. The exported function must be named `proxy`, not `middleware`. A `middleware.ts` at the root is silently ignored.
+
+**Fix:**
 ```ts
-// CORRECT
+// CORRECT — proxy.ts
 export async function proxy(request: NextRequest) { ... }
+export const config = { matcher: [...] }; // no `runtime` key — build error
 
-// WRONG — no-op in Next.js 16, will silently be ignored
+// WRONG — silently no-ops
 export function middleware(request: NextRequest) { ... }
 ```
+Note: `runtime` is not allowed in proxy.ts config — it always runs on Node.js.
 
-### params and searchParams are async
-In Next.js 16, `params` and `searchParams` passed to page/layout components are Promises. Always `await` them:
+---
 
+## Next.js 16 — params and cookies/headers are async
+
+**Symptom:** `params.id` is undefined; `cookies()` causes a type error.
+
+**Fix:**
 ```ts
-// CORRECT
+// Pages/layouts
 export default async function Page({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
 }
 
-// WRONG — params is a Promise, accessing .id directly returns undefined
-export default async function Page({ params }: { params: { id: string } }) {
-  const id = params.id; // undefined in Next.js 16
-}
-```
-
-### cookies() and headers() are async
-```ts
-// CORRECT
+// Server components
 const cookieStore = await cookies();
-
-// WRONG
-const cookieStore = cookies(); // type error in Next.js 16
+const headersList = await headers();
 ```
 
-## Supabase
+---
 
-### RLS is the real auth gate
-`proxy.ts` redirects unauthenticated users but RLS enforces data access at the DB level. Never skip RLS thinking proxy.ts is enough.
+## Tailwind v4 — no tailwind.config.ts, @theme is CSS-first
 
-### coach_form_assessments is coach-only
-This table must NEVER be queried in user-facing pages. The user sees ONLY the result of `getFormBadge(status)` which returns `"Solid Form ✅"` for `locked_in` and `null` for everything else. The raw `status` value must never reach the client.
+**Symptom:** Custom tokens not resolving, or shadcn init breaks fonts.
 
-### Server client vs browser client
-- `lib/supabase/server.ts` — for Server Components, Server Actions, Route Handlers
-- `lib/supabase/client.ts` — for Client Components only
-- Mixing them up causes auth issues (server client uses cookie store, browser client uses localStorage)
+**Cause:** Tailwind v4 uses CSS-first config. All design tokens live in the `@theme {}` block in `app/globals.css`. Font references inside `@theme` must be literal strings — `var()` references resolve at parse time and can't see Next.js runtime injections.
 
-### Service role key bypasses RLS
-Only use `SUPABASE_SERVICE_ROLE_KEY` for admin operations in Route Handlers. Never use it in client-side code or Server Components that render user data.
-
-## Tailwind v4
-
-### No tailwind.config.ts
-Tailwind v4 is CSS-first. All design tokens live in the `@theme {}` block in `app/globals.css`. **Do not create a `tailwind.config.ts`** — shadcn's `components.json` intentionally has an empty `tailwind.config` path.
-
-### @theme inline vs @theme
-Use `@theme` (without `inline`) for custom tokens in the root layer. Only use `@theme inline` inside `@layer` blocks. Getting this wrong causes tokens not to resolve.
-
-### Font references in @theme must be literal
-Do NOT use CSS variable references inside `@theme {}` — they resolve at parse time, not runtime:
+**Fix:**
 ```css
-/* WRONG — circular reference */
+/* CORRECT */
+--font-sans: "Inter", ui-sans-serif, system-ui, sans-serif;
+
+/* WRONG — circular */
 --font-sans: var(--font-sans);
 
 /* WRONG — next/font injects this at runtime, @theme can't see it */
 --font-sans: var(--font-inter);
-
-/* CORRECT — literal font name */
---font-sans: "Inter", ui-sans-serif, system-ui, sans-serif;
 ```
 
-## Supabase SSR (cookie handling in proxy.ts)
+---
 
-The proxy must call `supabase.auth.getUser()` (not `getSession()`) to securely refresh the session. `getSession()` reads from the cookie without re-validating — `getUser()` hits the Supabase auth server. Always use `getUser()` in proxy.ts.
+## Supabase — getUser() not getSession() in proxy.ts
 
-## shadcn components
+**Symptom:** Auth seems to work but sessions don't refresh correctly; stale tokens.
 
-Run `npx shadcn@latest add <component>` to add components — they're copied as source files into `components/ui/`. Check what's already there before adding duplicates.
+**Cause:** `getSession()` reads from the cookie without re-validating against the Supabase auth server. Only `getUser()` re-validates and refreshes the session token.
 
-## Monitor cookie parsing
+**Fix:** `proxy.ts` must use `supabase.auth.getUser()`.
 
-The kickoff route checks for the monitor cookie by parsing the raw `Cookie` header string. If the cookie name or value ever changes, update both `proxy.ts` and `app/api/monitor/kickoff/route.ts`. The cookie name is in `lib/constants.ts` (`MONITOR_COOKIE = "_bb_ok"`).
+---
+
+## Supabase — coach_form_assessments is coach-only, forever
+
+**Symptom:** Form assessment scores visible to users in the UI.
+
+**Cause:** The `coach_form_assessments` table was queried in a user-facing component.
+
+**Fix:** Users NEVER see raw form status. Use `getFormBadge(status)` from `lib/utils.ts`:
+- `locked_in` → `"Solid Form ✅"`
+- Everything else → `null`
+RLS on the table also enforces this at the DB level.
+
+---
+
+## Monitor — MONITOR_COOKIE name is the source of truth
+
+The monitor cookie name is `_bb_ok`, defined in `lib/constants.ts` as `MONITOR_COOKIE`. Both `proxy.ts` and `/api/monitor/kickoff/route.ts` parse the raw `Cookie` header for this value. If the name ever changes, update both files.

--- a/WIKI/index.md
+++ b/WIKI/index.md
@@ -1,103 +1,197 @@
+---
+type: project-index
+tags: [buildbase, index]
+last-updated: 2026-04-16
+---
+
 # BuildBase — Project Wiki
 
-> Read this before starting any task. Check WIKI/gotchas.md for known failures.
+> **Agents: read this file first.** 60 seconds of reading = no wasted tool calls.
+> Then read `WIKI/gotchas.md` before touching anything.
 
-## Status (as of scaffold)
+---
 
-- **Scaffolding:** Complete — all routes, types, Supabase clients, SQL migration, roadmap, CI workflow
-- **Batch 1:** Not started — auth, RBAC, profiles, seed
-- **Batches 2–8:** Not started
+## What This App Does
 
-## Architecture Overview
+BuildBase is a structured fitness coaching SaaS with RBAC (admin / coach / user). Coaches program 12-week strength plans, track client form, and send notes. Users log sets, view progress, and get automatically guided to their next session. The product is pre-scaffold but not yet feature-complete — agents are building it batch by batch via the `/monitor/roadmap` kickoff system.
 
-### File Map
+## Data Flow
+
+```
+Browser ──► proxy.ts (auth guard + PIN gate + Supabase session refresh)
+         ──► App Router server components (lib/supabase/server.ts)
+         ──► Supabase PostgreSQL (RLS enforced)
+
+Monitor ──► /monitor/roadmap (server component, reads GitHub PR status + Upstash KV)
+         ──► KickoffButton → POST /api/monitor/kickoff
+         ──► GitHub workflow_dispatch → claude-feature.yml
+         ──► Claude Code agent (reads GitHub Issue for spec, writes code, commits, pushes)
+         ──► PR marked ready → human reviews + merges
+```
+
+## Tech Stack
+
+| Layer | Technology |
+|---|---|
+| Framework | Next.js 16.2.2 — App Router, `proxy.ts` (not `middleware.ts`) |
+| UI | React 19, Tailwind v4 (CSS-first), shadcn/ui v4 (base-nova style) |
+| Auth + DB | Supabase (PostgreSQL + RLS + SSR auth via `@supabase/ssr`) |
+| KV store | Upstash Redis (`@upstash/redis`) — roadmap status overrides only |
+| Charts | Recharts |
+| Animation | Framer Motion |
+| DnD | dnd-kit (Batch 7) |
+| Toast | Sonner |
+| Server state | TanStack React Query |
+| Client state | Zustand |
+| Tests | Vitest + jsdom |
+| CI | GitHub Actions — `claude-feature.yml` (agent) + `ci.yml` (lint/test) |
+| Hosting | Vercel (auto-deploy `main`; preview on all branches) |
+| Package mgr | pnpm 9 |
+
+## Key Files
+
+| File | Purpose |
+|---|---|
+| `proxy.ts` | Auth guard + monitor PIN gate + Supabase session refresh. Next.js 16 — not middleware.ts |
+| `lib/types.ts` | All shared TypeScript interfaces — Profile, SessionLog, SetLog, CoachNote, etc. |
+| `lib/roadmap-data.ts` | Roadmap item definitions. `status`, `pr`, `issue` updated as work progresses |
+| `lib/storage.ts` | Upstash Redis KV — `getRoadmapOverrides()` / `setRoadmapOverride()`. Key: `bb:roadmap-overrides` |
+| `lib/github-api.ts` | GitHub REST helpers: `ensureBranchReady`, `createDraftPr`, `createIssue`, `getMainSha` |
+| `lib/supabase/server.ts` | Server Supabase client — use in Server Components, Route Handlers, Server Actions |
+| `lib/supabase/client.ts` | Browser Supabase client — use in Client Components only |
+| `lib/utils.ts` | `cn()`, `getFormBadge()`, `getDefaultWeight()`, `formatWeight()`, `hoursSince()` |
+| `lib/constants.ts` | `EFFORT_LABELS`, `SORENESS_LABELS`, `SESSIONS_PER_PAGE=3`, `SORENESS_PROMPT_GAP_HOURS=12` |
+| `lib/rbac.ts` | Role helpers — `requireRole()`, `hasRole()` |
+| `supabase/migrations/001_initial_schema.sql` | Full DB schema — run once in Supabase SQL Editor |
+| `supabase/seed.sql` | Default 12-week program seed data |
+| `app/globals.css` | Tailwind v4 `@theme` block — all design tokens here |
+| `.github/workflows/claude-feature.yml` | Agent workflow — `workflow_dispatch` → Claude Code implements a roadmap item |
+
+## Route Structure
 
 ```
 app/
-  (auth)/login, signup    → Public auth pages (Batch 1)
-  auth/callback           → Supabase OAuth callback
-  (app)/                  → Protected user routes (Batches 2–6)
-    dashboard/
-    sessions/
-    progress/
-    coach-notes/
-  (coach)/                → Coach-only routes (Batch 4)
-    clients/
-    clients/[id]/
-    playbook/
-  (admin)/                → Admin-only routes (Batches 5, 7)
-    users/
-    programs/
-  monitor/                → Dev monitor (Batch 8 — scaffold done)
-    login/
-    roadmap/
-  api/
-    auth/callback/        → Supabase auth exchange
-    monitor/login/        → PIN check, sets cookie
-    monitor/kickoff/      → Triggers GitHub workflow_dispatch
-
-lib/
-  supabase/client.ts      → Browser client (Client Components)
-  supabase/server.ts      → Server client (Server Components)
-  types.ts                → All shared types
-  utils.ts                → cn(), getFormBadge(), getDefaultWeight(), formatWeight(), hoursSince()
-  constants.ts            → Effort/soreness labels, SESSIONS_PER_PAGE, SORENESS_PROMPT_GAP_HOURS
-  roadmap-data.ts         → Roadmap items — update status/pr as batches complete
-
-components/
-  layout/Sidebar.tsx      → Role-aware nav (stub — implement Batch 1)
-  layout/Header.tsx       → Mobile header (stub — implement Batch 1)
-  ui/                     → shadcn components (add with: npx shadcn@latest add <component>)
-
-proxy.ts                  → Next.js 16 auth guard + monitor PIN gate + Supabase session refresh
-supabase/migrations/      → SQL schema (run once in Supabase SQL Editor)
-tests/                    → Vitest tests
-.github/workflows/        → claude-feature.yml (workflow_dispatch for roadmap kickoff)
+  (auth)/login            → /login          Public
+  (auth)/signup           → /signup         Public
+  (auth)/forgot-password  → /forgot-password Public
+  (auth)/reset-password   → /reset-password  Public
+  auth/callback           → OAuth callback   Public
+  (app)/dashboard         → /dashboard       Protected: all roles
+  (app)/sessions          → /sessions        Protected: user
+  (app)/progress          → /progress        Protected: user
+  (app)/coach-notes       → /coach-notes     Protected: user (coach-paired only)
+  (coach)/clients         → /clients         Protected: coach/admin
+  (coach)/clients/[id]    → /clients/:id     Protected: coach/admin
+  (coach)/playbook        → /playbook        Protected: coach/admin
+  (admin)/users           → /admin/users     Protected: admin only
+  (admin)/programs        → /admin/programs  Protected: admin only
+  monitor/login           → PIN gate         Public
+  monitor/roadmap         → Dev monitor      PIN-gated
 ```
 
-### Data flow
+## Database Schema (key tables)
 
-```
-Browser → proxy.ts (auth check + session refresh)
-       → App Router (Server Components fetch via lib/supabase/server.ts)
-       → Route Handlers (lib/supabase/server.ts with service role for admin ops)
+| Table | Purpose |
+|---|---|
+| `profiles` | Extends auth.users — `role`, `gender`, `coach_id`, `template_tier`, `onboarding_done` |
+| `programs` / `phases` | Program definitions — 3 phases, 12 weeks |
+| `workout_templates` | Per-week session templates (36 per program) |
+| `template_exercises` | Exercises with 6 weight defaults (3 tiers × 2 genders) |
+| `user_enrollments` | Links user to program + tracks current week/session |
+| `session_logs` | One per user per session — effort, soreness, completion |
+| `set_logs` | One per set logged — weight_used, reps_completed |
+| `coach_form_assessments` | **COACH-ONLY** — never expose status to user role |
+| `coach_notes` | Banner + history — `dismissed_at`, `read_at`, `sent_at` |
+| `personal_records` | Auto-detected PRs per exercise |
+| `milestones` | Achievement tracking |
 
-Monitor → /monitor/login (PIN → cookie)
-        → /monitor/roadmap (server component, fetches GitHub PR status live)
-        → KickoffButton → /api/monitor/kickoff → GitHub workflow_dispatch → claude-feature.yml
-```
+## KV Store
 
-## Design Tokens
+| Key | Type | Purpose |
+|---|---|---|
+| `bb:roadmap-overrides` | `Record<string, RoadmapOverride>` | Runtime status/pr/issue overrides for roadmap monitor items. Bypasses static `roadmap-data.ts` so clicking "Start" immediately shows in-progress without redeploy |
 
-See `app/globals.css` for full `@theme` block. Key colors:
+`RoadmapOverride = { status: "in-progress" \| "done" \| "paused", pr?: number, issue?: number, startedAt?: string }`
+
+Requires env vars: `UPSTASH_REDIS_REST_URL` + `UPSTASH_REDIS_REST_TOKEN` (Vercel env).
+Degrades gracefully to static data when not configured.
+
+## Environment Variables
+
+| Variable | Where set | Purpose |
+|---|---|---|
+| `NEXT_PUBLIC_SUPABASE_URL` | Vercel + local | Supabase project URL |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Vercel + local | Supabase public anon key |
+| `SUPABASE_SERVICE_ROLE_KEY` | Vercel (server only) | Bypasses RLS — admin ops only |
+| `ROADMAP_PIN` | Vercel | PIN for /monitor/login |
+| `GITHUB_TOKEN` | Vercel (server only) | Fine-grained PAT — needs Contents/PRs/Issues/Actions write |
+| `NEXT_PUBLIC_GITHUB_REPO` | Vercel | `omerskywalker/BuildBase` |
+| `NEXT_PUBLIC_APP_URL` | Vercel | `https://buildbase.io` |
+| `UPSTASH_REDIS_REST_URL` | Vercel | Upstash Redis endpoint |
+| `UPSTASH_REDIS_REST_TOKEN` | Vercel | Upstash Redis auth token |
+| `ANTHROPIC_API_KEY` | GitHub Actions secrets | Claude Code in `claude-feature.yml` |
+
+## Current Status (2026-04-16)
+
+| Batch | Items | Status |
+|---|---|---|
+| 1 — Foundation | Auth, RBAC, Profiles, Seed | PRs open (#7–10), in-progress in static data |
+| 2 — Session Tracker | Onboarding + 3 tracker items | Not started (issues #17, 22–24 exist) |
+| 3 — Phase View | Phase overview, detail modal, preview | Not started (issues #25–27) |
+| 4 — Coach Features | Playbook, clients, form assessment, notes | Not started (issues #28–31) |
+| 5 — Admin Panel | User mgmt, create user, overrides | Not started (issues #32–34) |
+| 6 — Metrics | Charts, milestones, trends | Not started (issues #35–37) |
+| 7 — Template Editor | Program editor, session DnD, exercise lib | Not started (issues #38–40) |
+| 8 — Monitor | Login, KickoffButton, Poller | **Done** |
+
+GitHub Issue numbers stamped in `lib/roadmap-data.ts` — kickoff never creates duplicates.
+
+## Design System
+
+Full spec in `WIKI/design-system.md`. Quick reference:
 
 | Token | Value | Use |
-|-------|-------|-----|
-| `bg-base` | `#0F1A14` | Body background |
+|---|---|---|
+| `bg-base` | `#0F1A14` | Page background |
 | `bg-surface` | `#152019` | Sidebar, headers |
 | `bg-elevated` | `#1C2A20` | Cards, panels |
 | `accent` | `#C84B1A` | CTAs, burnt orange |
 | `brand` | `#1C3A2A` | Forest green |
-| `content-primary` | `#E8F0E8` | Headings, values |
+| `content-primary` | `#E8F0E8` | Headings |
 | `content-secondary` | `#8A9E8A` | Labels |
-| `content-muted` | `#4A5A4A` | Timestamps |
+| `success` | `#2D7A3A` | Completed states |
+| `error` | `#B83020` | Errors |
+| `info` | `#3060A0` | In-progress, PR links |
 
-## Supabase Setup (required before Batch 1 works)
+App name rendering — must match everywhere:
+```tsx
+<span style={{ color: "#1C3A2A" }}>Build</span>
+<span style={{ color: "#C84B1A", fontWeight: 700 }}>Base</span>
+```
 
-1. Create project at supabase.com
-2. Run `supabase/migrations/001_initial_schema.sql` in SQL Editor
-3. Copy URL + anon key + service role key → `.env.local`
-4. Enable email auth in Supabase Auth settings
+## Conventions
 
-## Vercel Setup
+**Branch naming:**
+```
+feat/batch-{n}-{short-description}   roadmap batch work
+fix/{short-description}              bug fixes
+chore/{short-description}            deps, config, CI
+```
 
-1. Create project at vercel.com, connect to `omerskywalker/BuildBase`
-2. Add all env vars from `.env.example` in Vercel dashboard
-3. Vercel auto-deploys `main` on push. Preview deploys on all branches.
+**Commit format:**
+```
+type(scope): short description
 
-## Monitor/Roadmap Setup
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+```
 
-1. GitHub PAT: `github.com/settings/tokens` → `repo` + `workflow` scopes → set as `GITHUB_TOKEN` in Vercel
-2. `ANTHROPIC_API_KEY` → GitHub repo Actions secrets
-3. `ROADMAP_PIN` → Vercel env vars
-4. `NEXT_PUBLIC_GITHUB_REPO` = `omerskywalker/BuildBase` → Vercel env vars
+**PR process:** Branch off `main` → `pnpm tsc --noEmit` clean → `pnpm test` passing → PR targets `main`.
+
+**Parallel agents:** When a batch is `parallelizable: true`, each item has a FILE SCOPE CONTRACT in its GitHub Issue. Agents must only touch files listed under "Owns" and never touch files under "Avoid". Never modify `lib/roadmap-data.ts` in a parallel run — the kickoff API manages status via KV.
+
+## Navigation
+
+- [gotchas.md](gotchas.md) — **Read this before touching anything**
+- [agents.md](agents.md) — Agent-specific context for GitHub Actions runs
+- [design-system.md](design-system.md) — Full visual spec, component patterns, anti-patterns
+- [sessions/](sessions/) — Session logs

--- a/WIKI/sessions/2026-04-16.md
+++ b/WIKI/sessions/2026-04-16.md
@@ -1,0 +1,37 @@
+---
+type: session-log
+date: 2026-04-16
+tags: [monitor, kickoff, ci-fixes, wiki-setup, buildbase]
+last-updated: 2026-04-16
+---
+
+# Session — 2026-04-16
+
+## Items Shipped
+
+| PR | What |
+|---|---|
+| #41 | `id-token: write` permission, Framer Motion pulsing dot in KickoffButton, `ensureBranchReady` return value guard |
+| #46 | `mode: agent` + `direct_prompt` for claude-code-action@beta, stamp issue numbers #17–40 into roadmap-data.ts, close duplicate issues #42–47, fail-fast on empty Claude output |
+| #49 | Re-apply `mode: agent` + `direct_prompt` (lost in merge conflict resolution) |
+| —  | Wiki system bootstrapped with current state |
+
+## Decisions Made
+
+- **Upstash Redis** replaces deprecated `@vercel/kv` for roadmap KV store
+- **Issue numbers stamped statically** in `roadmap-data.ts` — kickoff route checks `item.issue` first, never creates duplicates
+- **Empty commit strategy** for branches: `ensureBranchReady` creates a same-tree commit via GitHub git data API to satisfy GitHub's "≥1 commit ahead of base" requirement for PR creation
+- **Verify-changes-exist step** added before commit in workflow — prevents PRs being falsely marked ready when Claude produces no output
+- **WIKI lives in repo** so GitHub Actions agents have access to it during runs
+
+## Gotchas Discovered
+
+- `claude-code-action@beta` API: `prompt` → `direct_prompt`, requires `mode: agent` for workflow_dispatch
+- Merge conflicts in `claude-feature.yml` silently revert critical fixes — always verify with grep after merge
+- Fine-grained PAT needs 4 permissions: Contents, Pull requests, Issues, Actions (all Read and write)
+- `ANTHROPIC_API_KEY` must be in GitHub Actions secrets separately from Vercel env vars
+- Branch creation alone (same SHA as main) causes 422 on PR creation — needs empty commit
+
+## Current Blockers
+
+- Upstash Redis env vars (`UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN`) not yet confirmed set in Vercel — live roadmap status updates won't work without them


### PR DESCRIPTION
## Summary

- Rewrites `WIKI/index.md` with current project status, full batch table, KV store docs, DB schema table, agent workflow data flow, and FILE SCOPE CONTRACT explanation
- Rewrites `WIKI/gotchas.md` with 12 dated entries covering all CI/agent failures discovered this session
- Rewrites `WIKI/agents.md` with step-by-step agent instructions, all workflow inputs, critical constraints (no git commands, no new PRs), and per-batch test requirements
- Adds `WIKI/sessions/2026-04-16.md` session log
- Updates `CLAUDE.md` to link `agents.md` and `design-system.md`, adds global wiki pointer

## Key gotchas documented

- `claude-code-action@beta`: `prompt:` → `direct_prompt:`, requires `mode: agent` for workflow_dispatch
- Merge conflicts on `claude-feature.yml` silently revert critical fixes — always verify with grep after merge
- Fine-grained PAT needs 4 permissions: Contents, Pull requests, Issues, Actions (all R+W)
- `ANTHROPIC_API_KEY` must be in GitHub Actions secrets separately from Vercel env vars
- Branch creation alone (same SHA as main) causes 422 on PR creation — needs empty commit

## Test plan

- [ ] WIKI files render cleanly on GitHub
- [ ] No broken links in `WIKI/index.md` navigation section

🤖 Generated with [Claude Code](https://claude.com/claude-code)