### PR TITLE
chore: use Vercel-generated Upstash env var names in storage.ts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,12 @@ NEXT_PUBLIC_APP_URL=https://buildbase.io
 # Monitor / Roadmap
 ROADMAP_PIN=
 GITHUB_TOKEN=
+NEXT_PUBLIC_GITHUB_REPO=
+
+# KV store — provision via Vercel Dashboard → Storage → Upstash KV
+# Vercel auto-populates these names when connecting an Upstash database
+UPSTASH_REDIS_REST_KV_REST_API_URL=
+UPSTASH_REDIS_REST_KV_REST_API_TOKEN=
 
 # Analytics (optional)
 NEXT_PUBLIC_GA_ID=

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -13,7 +13,10 @@ const KEY = "bb:roadmap-overrides";
 
 function getRedis(): Redis | null {
   try {
-    return Redis.fromEnv();
+    const url = process.env.UPSTASH_REDIS_REST_KV_REST_API_URL;
+    const token = process.env.UPSTASH_REDIS_REST_KV_REST_API_TOKEN;
+    if (!url || !token) return null;
+    return new Redis({ url, token });
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
- `Redis.fromEnv()` expects `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN` but Vercel auto-generates `UPSTASH_REDIS_REST_KV_REST_API_URL` / `UPSTASH_REDIS_REST_KV_REST_API_TOKEN` when connecting an Upstash database via the dashboard
- Switches `getRedis()` to `new Redis({ url, token })` with the actual env var names
- Updates `.env.example` to document the correct names

## Test plan
- [ ] Merge and redeploy — roadmap monitor KV writes should now persist across `router.refresh()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)