### PR TITLE
fix: guard completeOnboarding against null user

### DIFF
--- a/app/onboarding/actions.ts
+++ b/app/onboarding/actions.ts
@@ -1,0 +1,57 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import type { Gender, TemplateTier } from "@/lib/types";
+
+const VALID_GENDERS: Gender[] = ["male", "female", "other", "unset"];
+const VALID_TIERS: TemplateTier[] = ["pre_baseline", "default", "post_baseline"];
+
+export interface OnboardingData {
+  full_name: string;
+  gender: string;
+  template_tier: string;
+}
+
+export async function completeOnboarding(data: OnboardingData): Promise<void> {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const full_name = data.full_name.trim();
+
+  if (!full_name) {
+    throw new Error("Full name is required");
+  }
+
+  if (!VALID_GENDERS.includes(data.gender as Gender)) {
+    throw new Error("Invalid gender");
+  }
+
+  if (!VALID_TIERS.includes(data.template_tier as TemplateTier)) {
+    throw new Error("Invalid template tier");
+  }
+
+  const { error } = await supabase
+    .from("profiles")
+    .update({
+      full_name,
+      gender: data.gender,
+      template_tier: data.template_tier,
+      onboarding_done: true,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", user.id);
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  redirect("/dashboard");
+}

--- a/tests/onboarding.test.ts
+++ b/tests/onboarding.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn().mockImplementation((url: string) => {
+    throw new Error(`REDIRECT:${url}`);
+  }),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(),
+}));
+
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { completeOnboarding } from "@/app/onboarding/actions";
+
+describe("onboarding", () => {
+  describe("completeOnboarding", () => {
+    let mockEq: ReturnType<typeof vi.fn>;
+    let mockUpdate: ReturnType<typeof vi.fn>;
+    let mockGetUser: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+
+      mockEq = vi.fn().mockResolvedValue({ error: null });
+      mockUpdate = vi.fn().mockReturnValue({ eq: mockEq });
+      mockGetUser = vi.fn().mockResolvedValue({
+        data: { user: { id: "user-123" } },
+      });
+
+      vi.mocked(createClient).mockResolvedValue({
+        auth: { getUser: mockGetUser },
+        from: vi.fn().mockReturnValue({ update: mockUpdate }),
+      } as any);
+
+      vi.mocked(redirect).mockImplementation((url: string) => {
+        throw new Error(`REDIRECT:${url}`);
+      });
+    });
+
+    it("should complete onboarding with valid data", async () => {
+      await expect(
+        completeOnboarding({ full_name: "John Doe", gender: "male", template_tier: "default" })
+      ).rejects.toThrow("REDIRECT:/dashboard");
+      expect(mockUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ full_name: "John Doe", onboarding_done: true })
+      );
+    });
+
+    it("should trim whitespace from full name", async () => {
+      await expect(
+        completeOnboarding({ full_name: "  John  ", gender: "male", template_tier: "default" })
+      ).rejects.toThrow("REDIRECT:/dashboard");
+      expect(mockUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ full_name: "John" })
+      );
+    });
+
+    it("should throw error for empty full name", async () => {
+      await expect(
+        completeOnboarding({ full_name: "", gender: "male", template_tier: "default" })
+      ).rejects.toThrow("Full name is required");
+    });
+
+    it("should throw error for whitespace-only full name", async () => {
+      await expect(
+        completeOnboarding({ full_name: "   ", gender: "male", template_tier: "default" })
+      ).rejects.toThrow("Full name is required");
+    });
+
+    it("should throw error for invalid gender", async () => {
+      await expect(
+        completeOnboarding({ full_name: "John", gender: "invalid", template_tier: "default" })
+      ).rejects.toThrow("Invalid gender");
+    });
+
+    it("should throw error for invalid template tier", async () => {
+      await expect(
+        completeOnboarding({ full_name: "John", gender: "male", template_tier: "invalid" })
+      ).rejects.toThrow("Invalid template tier");
+    });
+
+    it("should handle all valid gender options", async () => {
+      for (const gender of ["male", "female", "other", "unset"]) {
+        await expect(
+          completeOnboarding({ full_name: "John", gender, template_tier: "default" })
+        ).rejects.toThrow("REDIRECT:/dashboard");
+      }
+    });
+
+    it("should handle all valid template tiers", async () => {
+      for (const tier of ["pre_baseline", "default", "post_baseline"]) {
+        await expect(
+          completeOnboarding({ full_name: "John", gender: "male", template_tier: tier })
+        ).rejects.toThrow("REDIRECT:/dashboard");
+      }
+    });
+
+    it("should redirect to login if no user", async () => {
+      mockGetUser.mockResolvedValue({ data: { user: null } });
+      await expect(
+        completeOnboarding({ full_name: "John", gender: "male", template_tier: "default" })
+      ).rejects.toThrow("REDIRECT:/login");
+    });
+
+    it("should handle database errors", async () => {
+      mockEq.mockResolvedValue({ error: { message: "Database error" } });
+      await expect(
+        completeOnboarding({ full_name: "John", gender: "male", template_tier: "default" })
+      ).rejects.toThrow("Database error");
+    });
+
+    it("should redirect to dashboard on success", async () => {
+      await expect(
+        completeOnboarding({ full_name: "John", gender: "male", template_tier: "default" })
+      ).rejects.toThrow("REDIRECT:/dashboard");
+      expect(redirect).toHaveBeenCalledWith("/dashboard");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `app/onboarding/actions.ts` — Server Action that completes user onboarding by updating the `profiles` table
- Guards against `user` being null before accessing `user.id` — redirects to `/login` if no session
- Validates `full_name` (non-empty after trim), `gender` (enum), and `template_tier` (enum) before hitting the DB
- Adds `tests/onboarding.test.ts` — 11 tests covering the null-user redirect, all valid enum values, whitespace trimming, and DB error handling

## No conflict risk

Both files are new additions — zero modifications to existing files.

## Test plan

- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm test` — 114/114 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)