### PR TITLE
fix: drop GitHub API cache in monitor — always live

### DIFF
--- a/app/monitor/roadmap/page.tsx
+++ b/app/monitor/roadmap/page.tsx
@@ -27,7 +27,7 @@ async function fetchPrStatus(pr: number): Promise<{ pr: GhPr; ci: CiStatus } | n
 
     const prRes = await fetch(`https://api.github.com/repos/${REPO}/pulls/${pr}`, {
       headers,
-      next: { revalidate: 60 },
+      cache: "no-store",
     });
     if (!prRes.ok) return null;
 
@@ -35,7 +35,7 @@ async function fetchPrStatus(pr: number): Promise<{ pr: GhPr; ci: CiStatus } | n
 
     const checksRes = await fetch(
       `https://api.github.com/repos/${REPO}/commits/${prData.head?.ref}/check-runs`,
-      { headers, next: { revalidate: 60 } }
+      { headers, cache: "no-store" }
     );
     let ci: CiStatus = { conclusion: null };
     if (checksRes.ok) {


### PR DESCRIPTION
## Summary

- Both `fetch()` calls in `fetchPrStatus` had `next: { revalidate: 60 }`, caching GitHub's PR and check-run responses for 60 seconds
- Even with `force-dynamic` on the page and the 30s `RoadmapPoller` firing `router.refresh()`, merged status could lag because the *fetch data cache* is separate from the page cache
- Swapped to `cache: "no-store"` on both calls — every render now gets a live response from GitHub

## Test plan
- [ ] Merge a PR while monitor is open — should flip to ✅ Done within one 30s poll cycle instead of up to 60s after
- [ ] Verify GitHub API responses are not rate-limited (authenticated token has 5,000 req/hr; 46 calls/render is well within limits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)