### PR TITLE
feat(2-4): Effort + soreness prompts

### DIFF
--- a/app/(app)/sessions/EffortPrompt.tsx
+++ b/app/(app)/sessions/EffortPrompt.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { EFFORT_LABELS } from "@/lib/constants";
+
+interface EffortPromptProps {
+  sessionLogId: string;
+  onDismiss: () => void;
+}
+
+const SCORES = [1, 2, 3, 4, 5] as const;
+type EffortScore = (typeof SCORES)[number];
+
+export default function EffortPrompt({ sessionLogId, onDismiss }: EffortPromptProps) {
+  const [selected, setSelected] = useState<EffortScore | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  // Auto-dismiss 4 seconds after a selection is confirmed
+  useEffect(() => {
+    if (selected === null) return;
+    const timer = setTimeout(onDismiss, 4000);
+    return () => clearTimeout(timer);
+  }, [selected, onDismiss]);
+
+  const handleSelect = async (score: EffortScore) => {
+    if (submitting || selected !== null) return;
+    setSubmitting(true);
+    try {
+      await fetch(`/api/sessions/${sessionLogId}/effort`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ score }),
+      });
+      setSelected(score);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-label="How was your effort today?"
+      className="rounded-xl border border-border-subtle bg-bg-elevated p-4 space-y-3"
+    >
+      <p className="text-sm font-semibold text-content-primary text-center">
+        How was your effort today?
+      </p>
+
+      <div className="flex gap-2 justify-center">
+        {SCORES.map((score) => {
+          const { emoji, label, color } = EFFORT_LABELS[score];
+          const isSelected = selected === score;
+          return (
+            <button
+              key={score}
+              type="button"
+              onClick={() => handleSelect(score)}
+              disabled={submitting || selected !== null}
+              aria-label={`${score} — ${label}`}
+              style={isSelected ? { borderColor: color, background: `${color}22` } : undefined}
+              className={`flex flex-col items-center gap-1 px-3 py-2 rounded-lg border transition-all
+                ${isSelected
+                  ? "opacity-100"
+                  : "border-border-subtle bg-bg-surface hover:bg-bg-hover disabled:opacity-40 disabled:cursor-not-allowed"
+                }`}
+            >
+              <span className="text-xl leading-none">{emoji}</span>
+              <span className="text-[10px] text-content-secondary font-medium">{label}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      {selected !== null && (
+        <p className="text-xs text-content-muted text-center">
+          {EFFORT_LABELS[selected].label} logged — closing in a moment…
+        </p>
+      )}
+    </div>
+  );
+}

--- a/app/(app)/sessions/SessionCard.tsx
+++ b/app/(app)/sessions/SessionCard.tsx
@@ -7,12 +7,16 @@ import { SessionLog, WorkoutTemplate, TemplateExercise, SetLog } from "@/lib/typ
 import { timeAgo } from "@/lib/utils";
 import { ChevronDown, ChevronRight, Play, CheckCircle, Loader2 } from "lucide-react";
 import SetRow from "./SetRow";
+import EffortPrompt from "./EffortPrompt";
+import SorenessPrompt from "./SorenessPrompt";
 
 interface SessionCardProps {
   session: SessionLog & { template?: WorkoutTemplate };
   autoExpanded?: boolean;
   userTier?: "pre_baseline" | "default" | "post_baseline";
   userGender?: "male" | "female" | "other" | "unset";
+  /** completed_at of the last OTHER completed session — used to gate the soreness prompt */
+  lastCompletedAt?: string | null;
 }
 
 interface ExerciseWithSets {
@@ -25,18 +29,23 @@ export default function SessionCard({
   autoExpanded = false,
   userTier = "default",
   userGender = "unset",
+  lastCompletedAt = null,
 }: SessionCardProps) {
   const [isExpanded, setIsExpanded] = useState(autoExpanded);
   const [isStarting, setIsStarting] = useState(false);
+  const [isCompleting, setIsCompleting] = useState(false);
   const [realSessionId, setRealSessionId] = useState<string | null>(
     session.id.startsWith("virtual-") ? null : session.id
   );
   const [exercises, setExercises] = useState<ExerciseWithSets[]>([]);
   const [loadingExercises, setLoadingExercises] = useState(false);
+  const [localIsComplete, setLocalIsComplete] = useState(session.is_complete);
+  const [showEffortPrompt, setShowEffortPrompt] = useState(false);
+  const [sorenessPrompted, setSorenessPrompted] = useState(session.soreness_prompted ?? false);
 
   const isVirtual = session.id.startsWith("virtual-");
   const sessionLogId = realSessionId;
-  const isCompleted = session.is_complete;
+  const isCompleted = localIsComplete;
   const isStarted = session.started_at !== null || realSessionId !== null;
   const sessionTitle = session.template?.title || `Session ${session.session_number}`;
   const dayLabel = session.template?.day_label || "";
@@ -95,13 +104,25 @@ export default function SessionCard({
     }
   };
 
+  const handleCompleteSession = async () => {
+    if (!sessionLogId || isCompleting) return;
+    setIsCompleting(true);
+    try {
+      await fetch(`/api/sessions/${sessionLogId}/complete`, { method: "POST" });
+      setLocalIsComplete(true);
+      setShowEffortPrompt(true);
+    } finally {
+      setIsCompleting(false);
+    }
+  };
+
   const handleToggleExpanded = () => {
     setIsExpanded((v) => !v);
   };
 
   const getStatusInfo = () => {
     if (isCompleted) return { icon: <CheckCircle className="w-4 h-4" />, text: "Completed", color: "text-success bg-success/10" };
-    if (isStarted) return { icon: <Play className="w-4 h-4" />, text: "In Progress", color: "text-blue-400 bg-blue-500/10" };
+    if (isStarted) return { icon: <Loader2 className="w-4 h-4" />, text: "In Progress", color: "text-blue-400 bg-blue-500/10" };
     return { icon: <Play className="w-4 h-4" />, text: "Not Started", color: "text-content-secondary bg-bg-hover" };
   };
 
@@ -143,6 +164,16 @@ export default function SessionCard({
 
       {isExpanded && (
         <CardContent className="pt-0 space-y-4">
+          {/* Soreness prompt — fires when gap since last session exceeds threshold */}
+          {sessionLogId && !isCompleted && (
+            <SorenessPrompt
+              sessionLogId={sessionLogId}
+              lastCompletedAt={lastCompletedAt ?? null}
+              sorenessPrompted={sorenessPrompted}
+              onDismiss={() => setSorenessPrompted(true)}
+            />
+          )}
+
           {!isStarted && !isCompleted && (
             <Button
               onClick={handleStartSession}
@@ -217,10 +248,34 @@ export default function SessionCard({
               {!loadingExercises && exercises.length === 0 && (
                 <p className="text-sm text-content-muted text-center py-4">No exercises found for this session.</p>
               )}
+
+              {/* Finish Session button — shown when exercises are loaded and session not yet complete */}
+              {!loadingExercises && exercises.length > 0 && !isCompleted && (
+                <Button
+                  onClick={handleCompleteSession}
+                  disabled={isCompleting}
+                  variant="outline"
+                  className="w-full border-success text-success hover:bg-success/10"
+                >
+                  {isCompleting ? (
+                    <><Loader2 className="w-4 h-4 mr-2 animate-spin" /> Finishing…</>
+                  ) : (
+                    "Finish Session"
+                  )}
+                </Button>
+              )}
             </div>
           )}
 
-          {isCompleted && (
+          {/* Effort prompt — shown immediately after Finish Session */}
+          {showEffortPrompt && sessionLogId && (
+            <EffortPrompt
+              sessionLogId={sessionLogId}
+              onDismiss={() => setShowEffortPrompt(false)}
+            />
+          )}
+
+          {isCompleted && !showEffortPrompt && (
             <div className="flex items-center justify-between pt-2 border-t border-border-subtle text-sm text-content-secondary">
               {session.completed_at && <span>Completed {timeAgo(session.completed_at)}</span>}
               {session.post_session_effort && <span>Effort: {session.post_session_effort}/5</span>}

--- a/app/(app)/sessions/SorenessPrompt.tsx
+++ b/app/(app)/sessions/SorenessPrompt.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState } from "react";
+import { SORENESS_LABELS, SORENESS_PROMPT_GAP_HOURS } from "@/lib/constants";
+import { hoursSince } from "@/lib/utils";
+
+interface SorenessPromptProps {
+  sessionLogId: string;
+  lastCompletedAt: string | null;
+  sorenessPrompted: boolean;
+  onDismiss: () => void;
+}
+
+const SCORES = [1, 2, 3, 4, 5] as const;
+type SorenessScore = (typeof SCORES)[number];
+
+export default function SorenessPrompt({
+  sessionLogId,
+  lastCompletedAt,
+  sorenessPrompted,
+  onDismiss,
+}: SorenessPromptProps) {
+  const [submitting, setSubmitting] = useState(false);
+  const [done, setDone] = useState(false);
+
+  // Only show if: gap is over threshold AND not yet prompted this session
+  const shouldShow =
+    !sorenessPrompted &&
+    !done &&
+    hoursSince(lastCompletedAt) > SORENESS_PROMPT_GAP_HOURS;
+
+  if (!shouldShow) return null;
+
+  const handleSelect = async (score: SorenessScore) => {
+    if (submitting) return;
+    setSubmitting(true);
+    try {
+      await fetch(`/api/sessions/${sessionLogId}/soreness`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ score }),
+      });
+      setDone(true);
+      onDismiss();
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-label="How are you feeling today?"
+      className="rounded-xl border border-border-subtle bg-bg-elevated p-4 space-y-3"
+    >
+      <p className="text-sm font-semibold text-content-primary text-center">
+        How&apos;s the body feeling today?
+      </p>
+      <p className="text-xs text-content-muted text-center">
+        It&apos;s been a while since your last session.
+      </p>
+
+      <div className="flex gap-2 justify-center">
+        {SCORES.map((score) => {
+          const { emoji, label } = SORENESS_LABELS[score];
+          return (
+            <button
+              key={score}
+              type="button"
+              onClick={() => handleSelect(score)}
+              disabled={submitting}
+              aria-label={`${score} — ${label}`}
+              className="flex flex-col items-center gap-1 px-3 py-2 rounded-lg border border-border-subtle bg-bg-surface hover:bg-bg-hover disabled:opacity-40 disabled:cursor-not-allowed transition-all"
+            >
+              <span className="text-xl leading-none">{emoji}</span>
+              <span className="text-[10px] text-content-secondary font-medium">{label}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/sessions/page.tsx
+++ b/app/(app)/sessions/page.tsx
@@ -58,6 +58,16 @@ async function getSessionsData(userId: string, currentWeek: number) {
     .eq("user_id", userId)
     .in("workout_template_id", templates.map(t => t.id));
 
+  // Find the most recently completed session (across all weeks) for the soreness gate
+  const { data: lastCompletedLog } = await supabase
+    .from("session_logs")
+    .select("completed_at")
+    .eq("user_id", userId)
+    .eq("is_complete", true)
+    .order("completed_at", { ascending: false })
+    .limit(1)
+    .single();
+
   // Create session objects, merging templates with logs
   const sessions = templates.map(template => {
     const existingLog = sessionLogs?.find(log => log.workout_template_id === template.id);
@@ -96,7 +106,8 @@ async function getSessionsData(userId: string, currentWeek: number) {
     sessions,
     totalWeeks,
     currentWeek,
-    enrollment
+    enrollment,
+    lastCompletedAt: lastCompletedLog?.completed_at ?? null
   };
 }
 
@@ -140,7 +151,7 @@ async function SessionsList({ userId, currentWeek }: { userId: string; currentWe
       .eq("id", userId)
       .single();
 
-    const { sessions, totalWeeks } = await getSessionsData(userId, currentWeek);
+    const { sessions, totalWeeks, lastCompletedAt } = await getSessionsData(userId, currentWeek);
 
     // Find the first incomplete session to auto-expand
     const firstIncompleteIndex = sessions.findIndex(session => !session.is_complete);
@@ -158,6 +169,7 @@ async function SessionsList({ userId, currentWeek }: { userId: string; currentWe
               autoExpanded={shouldExpand}
               userTier={profile?.template_tier ?? "default"}
               userGender={profile?.gender ?? "unset"}
+              lastCompletedAt={lastCompletedAt}
             />
           );
         })}

--- a/app/api/sessions/[sessionLogId]/complete/route.ts
+++ b/app/api/sessions/[sessionLogId]/complete/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+// POST /api/sessions/[sessionLogId]/complete
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ sessionLogId: string }> }
+) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { sessionLogId } = await params;
+
+  const { error } = await supabase
+    .from("session_logs")
+    .update({ is_complete: true, completed_at: new Date().toISOString() })
+    .eq("id", sessionLogId)
+    .eq("user_id", user.id);
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/sessions/[sessionLogId]/effort/route.ts
+++ b/app/api/sessions/[sessionLogId]/effort/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+// POST /api/sessions/[sessionLogId]/effort
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ sessionLogId: string }> }
+) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { sessionLogId } = await params;
+  const body = await request.json() as { score: number };
+  const score = body.score;
+
+  if (!Number.isInteger(score) || score < 1 || score > 5) {
+    return NextResponse.json({ error: "Score must be 1–5" }, { status: 400 });
+  }
+
+  const { error } = await supabase
+    .from("session_logs")
+    .update({ post_session_effort: score })
+    .eq("id", sessionLogId)
+    .eq("user_id", user.id);
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/sessions/[sessionLogId]/soreness/route.ts
+++ b/app/api/sessions/[sessionLogId]/soreness/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+// POST /api/sessions/[sessionLogId]/soreness
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ sessionLogId: string }> }
+) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { sessionLogId } = await params;
+  const body = await request.json() as { score: number };
+  const score = body.score;
+
+  if (!Number.isInteger(score) || score < 1 || score > 5) {
+    return NextResponse.json({ error: "Score must be 1–5" }, { status: 400 });
+  }
+
+  const { error } = await supabase
+    .from("session_logs")
+    .update({ pre_session_soreness: score, soreness_prompted: true })
+    .eq("id", sessionLogId)
+    .eq("user_id", user.id);
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ ok: true });
+}

--- a/tests/effort-soreness-prompts.test.ts
+++ b/tests/effort-soreness-prompts.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import { EFFORT_LABELS, SORENESS_LABELS, SORENESS_PROMPT_GAP_HOURS } from "@/lib/constants";
+import { hoursSince } from "@/lib/utils";
+
+// ─── Shared helpers ────────────────────────────────────────────────────────────
+
+/** Valid score range used by both prompts */
+const VALID_SCORES: number[] = [1, 2, 3, 4, 5];
+
+/** Server-side validation mirrors the API route logic */
+function isValidScore(score: number): boolean {
+  return Number.isInteger(score) && score >= 1 && score <= 5;
+}
+
+// ─── EFFORT_LABELS ─────────────────────────────────────────────────────────────
+
+describe("EFFORT_LABELS", () => {
+  it("has entries for all 5 scores", () => {
+    expect(Object.keys(EFFORT_LABELS)).toHaveLength(5);
+  });
+
+  it("each entry has emoji, label, and color", () => {
+    VALID_SCORES.forEach((score) => {
+      const entry = EFFORT_LABELS[score];
+      expect(entry).toBeDefined();
+      expect(typeof entry.emoji).toBe("string");
+      expect(typeof entry.label).toBe("string");
+      expect(typeof entry.color).toBe("string");
+      expect(entry.color).toMatch(/^#/);
+    });
+  });
+
+  it("score 1 is the easiest (Easy)", () => {
+    expect(EFFORT_LABELS[1].label).toBe("Easy");
+  });
+
+  it("score 5 is the hardest (Maxed)", () => {
+    expect(EFFORT_LABELS[5].label).toBe("Maxed");
+  });
+});
+
+// ─── SORENESS_LABELS ───────────────────────────────────────────────────────────
+
+describe("SORENESS_LABELS", () => {
+  it("has entries for all 5 scores", () => {
+    expect(Object.keys(SORENESS_LABELS)).toHaveLength(5);
+  });
+
+  it("each entry has emoji, label, and color", () => {
+    VALID_SCORES.forEach((score) => {
+      const entry = SORENESS_LABELS[score];
+      expect(entry).toBeDefined();
+      expect(typeof entry.emoji).toBe("string");
+      expect(typeof entry.label).toBe("string");
+      expect(typeof entry.color).toBe("string");
+    });
+  });
+
+  it("score 1 is worst soreness (Rough)", () => {
+    expect(SORENESS_LABELS[1].label).toBe("Rough");
+  });
+
+  it("score 5 is best recovery (Fresh)", () => {
+    expect(SORENESS_LABELS[5].label).toBe("Fresh");
+  });
+});
+
+// ─── Score validation (mirrors API route logic) ────────────────────────────────
+
+describe("isValidScore", () => {
+  it("accepts all scores 1–5", () => {
+    VALID_SCORES.forEach((score) => {
+      expect(isValidScore(score)).toBe(true);
+    });
+  });
+
+  it("rejects 0", () => {
+    expect(isValidScore(0)).toBe(false);
+  });
+
+  it("rejects 6", () => {
+    expect(isValidScore(6)).toBe(false);
+  });
+
+  it("rejects negative values", () => {
+    expect(isValidScore(-1)).toBe(false);
+  });
+
+  it("rejects non-integers", () => {
+    expect(isValidScore(2.5)).toBe(false);
+    expect(isValidScore(NaN)).toBe(false);
+  });
+});
+
+// ─── hoursSince + soreness gate ────────────────────────────────────────────────
+
+describe("soreness prompt gate", () => {
+  it("SORENESS_PROMPT_GAP_HOURS is 12", () => {
+    expect(SORENESS_PROMPT_GAP_HOURS).toBe(12);
+  });
+
+  it("fires when gap exceeds threshold", () => {
+    const thirteenHoursAgo = new Date(Date.now() - 13 * 60 * 60 * 1000).toISOString();
+    expect(hoursSince(thirteenHoursAgo)).toBeGreaterThan(SORENESS_PROMPT_GAP_HOURS);
+  });
+
+  it("does not fire when gap is under threshold", () => {
+    const threeHoursAgo = new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString();
+    expect(hoursSince(threeHoursAgo)).toBeLessThan(SORENESS_PROMPT_GAP_HOURS);
+  });
+
+  it("returns Infinity for null (never completed)", () => {
+    expect(hoursSince(null)).toBe(Infinity);
+  });
+
+  it("always fires when lastCompletedAt is null", () => {
+    // Infinity > any threshold
+    expect(hoursSince(null) > SORENESS_PROMPT_GAP_HOURS).toBe(true);
+  });
+});


### PR DESCRIPTION
## Roadmap Item `2-4`
**Effort + soreness prompts**
End-of-session 5-button effort prompt; pre-session soreness prompt when 12h+ gap since last session.
Closes #24
---
🤖 Implemented by [Claude Code](https://claude.ai/claude-code) via workflow dispatch.