### PR TITLE
fix: create user enrollment on onboarding completion

### DIFF
--- a/app/onboarding/actions.ts
+++ b/app/onboarding/actions.ts
@@ -38,7 +38,7 @@ export async function completeOnboarding(data: OnboardingData): Promise<void> {
     throw new Error("Invalid template tier");
   }
 
-  const { error } = await supabase
+  const { error: profileError } = await supabase
     .from("profiles")
     .update({
       full_name,
@@ -49,8 +49,33 @@ export async function completeOnboarding(data: OnboardingData): Promise<void> {
     })
     .eq("id", user.id);
 
-  if (error) {
-    throw new Error(`Failed to complete onboarding: ${error.message}`);
+  if (profileError) {
+    throw new Error(`Failed to complete onboarding: ${profileError.message}`);
+  }
+
+  // Enroll user in the active program so Sessions/Progress pages work
+  const { data: program } = await supabase
+    .from("programs")
+    .select("id")
+    .eq("is_active", true)
+    .limit(1)
+    .single();
+
+  if (!program) {
+    throw new Error("No active program found. Please contact support.");
+  }
+
+  const { error: enrollmentError } = await supabase
+    .from("user_enrollments")
+    .insert({
+      user_id: user.id,
+      program_id: program.id,
+      template_tier: data.template_tier,
+      gender_applied: data.gender,
+    });
+
+  if (enrollmentError) {
+    throw new Error(`Failed to create enrollment: ${enrollmentError.message}`);
   }
 
   redirect("/dashboard");

--- a/supabase/migrations/003_enrollment_self_insert.sql
+++ b/supabase/migrations/003_enrollment_self_insert.sql
@@ -1,0 +1,6 @@
+-- Allow users to create their own enrollment during onboarding.
+-- The existing "enrollments_own" policy only covers SELECT.
+-- The "enrollments_admin" policy covers ALL but only for admins.
+CREATE POLICY "enrollments_self_insert" ON user_enrollments
+  FOR INSERT
+  WITH CHECK (user_id = auth.uid());

--- a/tests/onboarding.test.ts
+++ b/tests/onboarding.test.ts
@@ -7,13 +7,27 @@ vi.mock('next/navigation', () => ({
   redirect: vi.fn(),
 }))
 
-// Mock Supabase client
-const mockUpdate = vi.fn()
-const mockEq = vi.fn()
-const mockFrom = vi.fn()
+// Per-table mock chains
+const mockProfileEq = vi.fn()
+const mockProfileUpdate = vi.fn()
+
+const mockProgramSingle = vi.fn()
+const mockProgramLimit = vi.fn()
+const mockProgramEq = vi.fn()
+const mockProgramSelect = vi.fn()
+
+const mockEnrollmentInsert = vi.fn()
+
 const mockAuth = {
   getUser: vi.fn()
 }
+
+const mockFrom = vi.fn((table: string) => {
+  if (table === 'profiles') return { update: mockProfileUpdate }
+  if (table === 'programs') return { select: mockProgramSelect }
+  if (table === 'user_enrollments') return { insert: mockEnrollmentInsert }
+  return {}
+})
 
 vi.mock('@/lib/supabase/server', () => ({
   createClient: vi.fn(() => ({
@@ -25,16 +39,23 @@ vi.mock('@/lib/supabase/server', () => ({
 describe('Onboarding', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    
-    // Set up default mock chain
-    mockEq.mockReturnValue({ error: null })
-    mockUpdate.mockReturnValue({ eq: mockEq })
-    mockFrom.mockReturnValue({ update: mockUpdate })
+
+    // profiles: .update(...).eq(...)
+    mockProfileEq.mockReturnValue({ error: null })
+    mockProfileUpdate.mockReturnValue({ eq: mockProfileEq })
+
+    // programs: .select("id").eq(...).limit(1).single()
+    mockProgramSingle.mockResolvedValue({ data: { id: 'program-abc' } })
+    mockProgramLimit.mockReturnValue({ single: mockProgramSingle })
+    mockProgramEq.mockReturnValue({ limit: mockProgramLimit })
+    mockProgramSelect.mockReturnValue({ eq: mockProgramEq })
+
+    // user_enrollments: .insert(...)
+    mockEnrollmentInsert.mockResolvedValue({ error: null })
   })
 
   describe('completeOnboarding', () => {
-    it('should successfully update profile with valid data', async () => {
-      // Mock authenticated user
+    it('should successfully update profile and create enrollment', async () => {
       mockAuth.getUser.mockResolvedValue({
         data: { user: { id: 'user-123' } }
       })
@@ -48,14 +69,26 @@ describe('Onboarding', () => {
       await completeOnboarding(onboardingData)
 
       expect(mockFrom).toHaveBeenCalledWith('profiles')
-      expect(mockUpdate).toHaveBeenCalledWith({
+      expect(mockProfileUpdate).toHaveBeenCalledWith({
         full_name: 'John Doe',
         gender: 'male',
         template_tier: 'default',
         onboarding_done: true,
         updated_at: expect.any(String)
       })
-      expect(mockEq).toHaveBeenCalledWith('id', 'user-123')
+      expect(mockProfileEq).toHaveBeenCalledWith('id', 'user-123')
+
+      expect(mockFrom).toHaveBeenCalledWith('programs')
+      expect(mockProgramSelect).toHaveBeenCalledWith('id')
+      expect(mockProgramEq).toHaveBeenCalledWith('is_active', true)
+
+      expect(mockFrom).toHaveBeenCalledWith('user_enrollments')
+      expect(mockEnrollmentInsert).toHaveBeenCalledWith({
+        user_id: 'user-123',
+        program_id: 'program-abc',
+        template_tier: 'default',
+        gender_applied: 'male',
+      })
     })
 
     it('should throw error when user not authenticated', async () => {
@@ -72,14 +105,13 @@ describe('Onboarding', () => {
       await expect(completeOnboarding(onboardingData)).rejects.toThrow('User not authenticated')
     })
 
-    it('should throw error when database update fails', async () => {
+    it('should throw error when profile update fails', async () => {
       mockAuth.getUser.mockResolvedValue({
         data: { user: { id: 'user-123' } }
       })
 
-      // Mock database error
-      mockEq.mockReturnValue({ 
-        error: { message: 'Database error' } 
+      mockProfileEq.mockReturnValue({
+        error: { message: 'Database error' }
       })
 
       const onboardingData: OnboardingData = {
@@ -89,6 +121,40 @@ describe('Onboarding', () => {
       }
 
       await expect(completeOnboarding(onboardingData)).rejects.toThrow('Failed to complete onboarding')
+    })
+
+    it('should throw error when no active program exists', async () => {
+      mockAuth.getUser.mockResolvedValue({
+        data: { user: { id: 'user-123' } }
+      })
+
+      mockProgramSingle.mockResolvedValue({ data: null })
+
+      const onboardingData: OnboardingData = {
+        full_name: 'John Doe',
+        gender: 'male',
+        template_tier: 'default'
+      }
+
+      await expect(completeOnboarding(onboardingData)).rejects.toThrow('No active program found')
+    })
+
+    it('should throw error when enrollment insert fails', async () => {
+      mockAuth.getUser.mockResolvedValue({
+        data: { user: { id: 'user-123' } }
+      })
+
+      mockEnrollmentInsert.mockResolvedValue({
+        error: { message: 'Enrollment error' }
+      })
+
+      const onboardingData: OnboardingData = {
+        full_name: 'John Doe',
+        gender: 'male',
+        template_tier: 'default'
+      }
+
+      await expect(completeOnboarding(onboardingData)).rejects.toThrow('Failed to create enrollment')
     })
 
     it('should trim whitespace from full_name', async () => {
@@ -104,7 +170,7 @@ describe('Onboarding', () => {
 
       await completeOnboarding(onboardingData)
 
-      expect(mockUpdate).toHaveBeenCalledWith({
+      expect(mockProfileUpdate).toHaveBeenCalledWith({
         full_name: 'John Doe',
         gender: 'female',
         template_tier: 'pre_baseline',
@@ -129,7 +195,7 @@ describe('Onboarding', () => {
 
         await completeOnboarding(onboardingData)
 
-        expect(mockUpdate).toHaveBeenCalledWith(
+        expect(mockProfileUpdate).toHaveBeenCalledWith(
           expect.objectContaining({ gender })
         )
       }
@@ -151,7 +217,7 @@ describe('Onboarding', () => {
 
         await completeOnboarding(onboardingData)
 
-        expect(mockUpdate).toHaveBeenCalledWith(
+        expect(mockProfileUpdate).toHaveBeenCalledWith(
           expect.objectContaining({ template_tier })
         )
       }


### PR DESCRIPTION
## Summary
- **Root cause:** `completeOnboarding()` updated the user's profile but never inserted a `user_enrollments` row. Every downstream page (Sessions, Progress, Milestones) queries this table and threw "No active enrollment found."
- After profile update, now queries `programs` for the active program and inserts a `user_enrollments` row linking the user to it with their chosen tier and gender.
- Adds RLS migration (`003_enrollment_self_insert.sql`) allowing users to insert their own enrollment — previously only admins had write access.

## Important
**Run migration `003_enrollment_self_insert.sql` in the Supabase SQL Editor** on production after merging, or the insert will be blocked by RLS.

For existing users who already completed onboarding without an enrollment, run:
```sql
INSERT INTO user_enrollments (user_id, program_id, template_tier, gender_applied)
SELECT p.id, prog.id, p.template_tier, p.gender
FROM profiles p
CROSS JOIN programs prog
WHERE p.onboarding_done = true
  AND prog.is_active = true
  AND NOT EXISTS (SELECT 1 FROM user_enrollments e WHERE e.user_id = p.id);
```

## Test plan
- [ ] New user signup → onboarding → verify `user_enrollments` row created
- [ ] After onboarding, `/sessions` loads instead of showing error
- [ ] After onboarding, `/progress` loads instead of showing error
- [ ] Existing user without enrollment → run backfill SQL → pages load

🤖 Generated with [Claude Code](https://claude.com/claude-code)