### PR TITLE
chore: close stale issues and update roadmap data

### DIFF
--- a/lib/roadmap-data.ts
+++ b/lib/roadmap-data.ts
@@ -317,6 +317,7 @@ export const ROADMAP: RoadmapBatch[] = [
         status: "done",
         tests: false,
         branch: "feat/batch-5-overrides",
+        pr: 86,
         issue: 34,
         scope: {
           owns: ["app/(admin)/overrides/", "app/api/admin/overrides/"],
@@ -366,6 +367,7 @@ export const ROADMAP: RoadmapBatch[] = [
         status: "done",
         tests: false,
         branch: "feat/batch-6-insights",
+        pr: 89,
         issue: 37,
         scope: {
           owns: ["app/(app)/progress/trends/", "components/TrendChart.tsx"],
@@ -387,6 +389,7 @@ export const ROADMAP: RoadmapBatch[] = [
         status: "done",
         tests: false,
         branch: "feat/batch-7-program-editor",
+        pr: 91,
         issue: 38,
         scope: {
           owns: ["app/(admin)/programs/page.tsx", "app/(admin)/programs/[id]/page.tsx", "app/api/admin/programs/"],
@@ -414,6 +417,7 @@ export const ROADMAP: RoadmapBatch[] = [
         status: "done",
         tests: false,
         branch: "feat/batch-7-exercise-library",
+        pr: 90,
         issue: 40,
         scope: {
           owns: ["app/(admin)/programs/[id]/exercises/", "app/api/admin/exercises/"],


### PR DESCRIPTION
## Summary
- Closed 5 stale GitHub issues (#18, #19, #20, #21, #33) whose PRs were already merged
- Added missing `pr` numbers to roadmap items 5-3 (PR #86), 6-3 (PR #89), 7-1 (PR #91), 7-3 (PR #90)

## Test plan
- [ ] Verify roadmap monitor renders correct PR links
- [ ] Verify no TypeScript errors (`npx tsc --noEmit` passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)