### PR TITLE
infra: Roadmap V2 orchestrator + monitor UI + Claude Code workflows

### DIFF
--- a/.github/workflows/claude-feature.yml
+++ b/.github/workflows/claude-feature.yml
@@ -1,0 +1,283 @@
+name: Claude Feature Implementation
+
+on:
+  workflow_dispatch:
+    inputs:
+      item_id:
+        description: "Roadmap item ID (e.g. 1-1)"
+        required: true
+        type: string
+      item_title:
+        description: "Roadmap item title"
+        required: true
+        type: string
+      item_description:
+        description: "Full implementation spec"
+        required: true
+        type: string
+      branch_name:
+        description: "Branch name (already created by kickoff API)"
+        required: true
+        type: string
+      issue_number:
+        description: "GitHub Issue number"
+        required: false
+        default: ""
+        type: string
+      pr_number:
+        description: "Draft PR number (already created by kickoff API)"
+        required: false
+        default: ""
+        type: string
+      retry:
+        description: "Is this a retry run?"
+        required: false
+        default: "false"
+        type: string
+
+jobs:
+  implement:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+
+    steps:
+      - name: Checkout feature branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch_name }}
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile || pnpm install
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      # ── Phase 1: Update roadmap status to in-progress ────────────────────
+      - name: Mark roadmap item in-progress
+        run: |
+          if [ -f "lib/roadmap-data.ts" ]; then
+            sed -i "s/id: \"${{ inputs.item_id }}\"/id: \"${{ inputs.item_id }}\"/" lib/roadmap-data.ts
+            # Find the item block and update status
+            python3 -c "
+          import re
+          with open('lib/roadmap-data.ts', 'r') as f:
+              content = f.read()
+          # Find the item by ID and update its status
+          pattern = r'(id: \"${{ inputs.item_id }}\".*?status: \")not-started(\")'
+          content = re.sub(pattern, r'\1in-progress\2', content, flags=re.DOTALL)
+          with open('lib/roadmap-data.ts', 'w') as f:
+              f.write(content)
+          "
+            git add lib/roadmap-data.ts
+            git diff --cached --quiet || git commit -m "chore: mark ${{ inputs.item_id }} in-progress in roadmap"
+            git push origin "${{ inputs.branch_name }}"
+          fi
+
+      # ── Phase 2: Agent implementation ────────────────────────────────────
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          mode: agent
+          direct_prompt: |
+            You are implementing roadmap item ${{ inputs.item_id }} for BuildBase.
+
+            **Item:** ${{ inputs.item_title }}
+            **Branch:** ${{ inputs.branch_name }}
+            ${{ inputs.issue_number != '' && format('**GitHub Issue:** #{0}', inputs.issue_number) || '' }}
+            ${{ inputs.pr_number != '' && format('**Draft PR:** #{0} — already open, push commits to it. Do NOT create a new PR.', inputs.pr_number) || '' }}
+
+            ## Project Architecture (READ THIS FIRST)
+
+            This is a **pnpm monorepo** with a React SPA frontend and Express API backend:
+
+            ```
+            artifacts/buildbase/    → React SPA (Vite, Tailwind, shadcn, Recharts)
+            artifacts/api-server/   → Express API server (TypeScript)
+            lib/                    → Shared packages (roadmap-data, db, api-spec)
+            supabase/               → Schema, migrations, seed data
+            ```
+
+            **NOT a Next.js app.** No App Router, no server components, no middleware.ts/proxy.ts.
+
+            ### Key files
+            - `artifacts/buildbase/src/lib/api.ts` — apiFetch wrapper (auth token forwarding)
+            - `artifacts/buildbase/src/lib/types.ts` — shared TypeScript types
+            - `artifacts/buildbase/src/lib/auth-context.tsx` — React auth context
+            - `artifacts/api-server/src/app.ts` — Express app setup
+            - `artifacts/api-server/src/lib/supabase.ts` — Supabase client + getAuthUser helper
+            - `supabase/schema.sql` — full database schema (14 tables, RLS on all)
+
+            ### RBAC
+            - **admin** — full access, creates users/coaches, edits programs
+            - **coach** — sees own clients, sends notes, marks form assessments
+            - **user** — sees own data only
+
+            ### Design tokens
+            - bg-base: #EDE4D3, bg-surface: #E5DAC8, bg-elevated: #E8DECE
+            - content-primary: #2C1A10, content-secondary: #6B5A48
+            - brand: #1C3A2A (forest green), accent: #C84B1A (burnt orange)
+            - UI library: shadcn/ui, lucide-react icons, sonner toasts, recharts
+
+            ## Implementation Steps
+
+            1. Read GitHub Issue #121 (Orchestrator — Agent Operating Rules) for mandatory constraints.
+            ${{ inputs.issue_number != '' && format('2. Read GitHub Issue #{0} for the full spec, acceptance criteria, and context.', inputs.issue_number) || '2. Read the item description below.' }}
+            3. Check open PRs (`gh pr list --state open`) to verify no scope conflicts.
+            4. Implement the feature/fix described.
+            5. Write tests for any new functionality that involves logic, API calls, or user interaction.
+            6. Run `pnpm run typecheck` and fix all type errors.
+            7. Run `pnpm run build` and verify it succeeds.
+
+            ## Item Description
+
+            ${{ inputs.item_description }}
+
+            ## Critical Constraints
+
+            - Do NOT run `git add`, `git commit`, or `git push` — the workflow handles this.
+            - Do NOT create a new PR — use the existing draft PR if one exists.
+            - Do NOT modify `lib/roadmap-data.ts` — the workflow manages roadmap status.
+            - Use `sonner` toast for user feedback (already installed).
+            - Use existing `apiFetch` or `apiFetchJson` from `artifacts/buildbase/src/lib/api.ts`.
+            - Follow existing patterns in the codebase — don't introduce new libraries without justification.
+
+      # ── Phase 3: Self-healing CI ─────────────────────────────────────────
+      - name: Type check
+        id: typecheck
+        run: |
+          if ! pnpm run typecheck 2>&1 | tee /tmp/ci-typecheck.txt; then
+            cp /tmp/ci-typecheck.txt .ci-typecheck-errors.txt
+            echo "failed=true" >> "$GITHUB_OUTPUT"
+          fi
+        continue-on-error: true
+
+      - name: Build
+        id: build
+        run: |
+          if ! pnpm run build 2>&1 | tee /tmp/ci-build.txt; then
+            cp /tmp/ci-build.txt .ci-build-errors.txt
+            echo "failed=true" >> "$GITHUB_OUTPUT"
+          fi
+        continue-on-error: true
+
+      - name: Self-heal — fix CI failures
+        if: steps.typecheck.outputs.failed == 'true' || steps.build.outputs.failed == 'true'
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          mode: agent
+          direct_prompt: |
+            The implementation for roadmap item ${{ inputs.item_id }} has CI failures.
+
+            1. Read `.ci-typecheck-errors.txt` if it exists — type check errors.
+            2. Read `.ci-build-errors.txt` if it exists — build errors.
+
+            Common fixes:
+            - JSX in a `.ts` file → rename to `.tsx`
+            - Missing imports → add them
+            - Strict null checks → use `T | null` or add guards
+
+            Fix all errors, then verify with `pnpm run typecheck` and `pnpm run build`.
+
+            Do NOT run `git add`, `git commit`, or `git push`.
+            Do NOT delete the `.ci-*` files.
+
+      - name: Clean up error files
+        if: always()
+        run: rm -f .ci-typecheck-errors.txt .ci-build-errors.txt
+
+      - name: Type check (final)
+        if: steps.typecheck.outputs.failed == 'true' || steps.build.outputs.failed == 'true'
+        run: pnpm run typecheck
+
+      - name: Build (final)
+        if: steps.typecheck.outputs.failed == 'true' || steps.build.outputs.failed == 'true'
+        run: pnpm run build
+
+      # ── Phase 4: Code review ─────────────────────────────────────────────
+      - name: Self-review before commit
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          mode: agent
+          direct_prompt: |
+            You are reviewing the changes made for roadmap item ${{ inputs.item_id }}: "${{ inputs.item_title }}".
+
+            Run `git diff` to see all uncommitted changes.
+
+            Review checklist:
+            1. **Security**: No XSS (dangerouslySetInnerHTML without sanitization), no SQL injection,
+               no exposed secrets, no raw error.message sent to clients.
+            2. **Error handling**: All apiFetch calls check response.ok. All catches show user feedback.
+            3. **Types**: No `any` casts. No `as unknown as X` escapes.
+            4. **Consistency**: Follows existing patterns in the codebase.
+            5. **Tests**: New logic has tests. Tests actually assert meaningful behavior.
+            6. **Dead code**: No commented-out code, no unused imports.
+            7. **Scope**: Changes are limited to what the issue describes — no drive-by refactors.
+
+            If you find issues, fix them. If everything looks good, do nothing.
+
+            Do NOT run `git add`, `git commit`, or `git push`.
+
+      # ── Phase 5: Commit and push ─────────────────────────────────────────
+      - name: Verify changes exist
+        run: |
+          git add -A
+          if git diff --cached --quiet; then
+            echo "::error::Claude Code produced no file changes."
+            exit 1
+          fi
+          echo "Changes staged:"
+          git diff --cached --stat
+
+      - name: Commit and push
+        run: |
+          git commit -m "feat(${{ inputs.item_id }}): ${{ inputs.item_title }}
+
+          Implements roadmap item ${{ inputs.item_id }}.
+          ${{ inputs.issue_number != '' && format('Closes #{0}', inputs.issue_number) || '' }}
+
+          Co-Authored-By: Claude Code <noreply@anthropic.com>"
+          git push origin "${{ inputs.branch_name }}"
+
+      - name: Mark PR ready for review
+        if: ${{ inputs.pr_number != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr ready ${{ inputs.pr_number }} --repo ${{ github.repository }} || true
+
+      # ── Failure reporting ────────────────────────────────────────────────
+      - name: Mark item failed
+        if: failure()
+        env:
+          APP_URL: ${{ secrets.APP_URL }}
+          ROADMAP_PIN: ${{ secrets.ROADMAP_PIN }}
+        run: |
+          if [ -z "$APP_URL" ] || [ -z "$ROADMAP_PIN" ]; then
+            echo "APP_URL or ROADMAP_PIN not set — skipping failure report"
+            exit 0
+          fi
+          curl -s -o /dev/null -w "%{http_code}" \
+            -X POST "${APP_URL}/api/monitor/fail" \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer ${ROADMAP_PIN}" \
+            -d "{\"itemId\": \"${{ inputs.item_id }}\"}"

--- a/.github/workflows/stamp-done.yml
+++ b/.github/workflows/stamp-done.yml
@@ -1,0 +1,64 @@
+name: Stamp Roadmap Item Done
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  stamp:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Extract item ID from PR title
+        id: extract
+        run: |
+          TITLE="${{ github.event.pull_request.title }}"
+          # Match feat(1-2): or fix(2-3): pattern
+          ITEM_ID=$(echo "$TITLE" | grep -oP '(?:feat|fix|chore|refactor|perf)\((\K[0-9]+-[0-9]+)' || true)
+          if [ -z "$ITEM_ID" ]; then
+            echo "No roadmap item ID found in PR title: $TITLE"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "item_id=$ITEM_ID" >> "$GITHUB_OUTPUT"
+            echo "Found item ID: $ITEM_ID"
+          fi
+
+      - name: Update roadmap status to done
+        if: steps.extract.outputs.skip != 'true'
+        run: |
+          ITEM_ID="${{ steps.extract.outputs.item_id }}"
+          PR_NUM="${{ github.event.pull_request.number }}"
+
+          python3 -c "
+          import re
+          with open('lib/roadmap-data.ts', 'r') as f:
+              content = f.read()
+
+          # Update status to done
+          pattern = r'(id: \"${ITEM_ID}\".*?status: \")[^\"]*(\")'
+          content = re.sub(pattern, r'\1done\2', content, flags=re.DOTALL)
+
+          # Update PR number
+          pattern = r'(id: \"${ITEM_ID}\".*?)(pr: \d+|pr: undefined)'
+          content = re.sub(pattern, r'\1pr: ${PR_NUM}', content, flags=re.DOTALL)
+
+          with open('lib/roadmap-data.ts', 'w') as f:
+              f.write(content)
+          "
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add lib/roadmap-data.ts
+          git diff --cached --quiet || {
+            git commit -m "chore: stamp $ITEM_ID done (PR #$PR_NUM merged)"
+            git push origin main
+          }

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,11 @@ Thumbs.db
 # Replit
 .cache/
 .local/
+
+# Next.js (migration backup dev artifacts)
+.next/
+
+# Environment
+.env
+.env.local
+.env.*.local

--- a/artifacts/api-server/src/routes/index.ts
+++ b/artifacts/api-server/src/routes/index.ts
@@ -7,6 +7,7 @@ import coachRouter from "./coach";
 import adminRouter from "./admin";
 import templatesRouter from "./templates";
 import quickLogRouter from "./quick-log";
+import monitorRouter from "./monitor";
 
 const router: IRouter = Router();
 
@@ -18,5 +19,6 @@ router.use("/coach", coachRouter);
 router.use("/admin", adminRouter);
 router.use("/templates", templatesRouter);
 router.use("/quick-log", quickLogRouter);
+router.use("/monitor", monitorRouter);
 
 export default router;

--- a/artifacts/api-server/src/routes/monitor.ts
+++ b/artifacts/api-server/src/routes/monitor.ts
@@ -1,0 +1,216 @@
+import { Router, type Request, type Response } from "express";
+import { logger } from "../lib/logger";
+
+const router = Router();
+
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+const REPO = process.env.GITHUB_REPO ?? "omerskywalker/BuildBase";
+const ROADMAP_PIN = process.env.ROADMAP_PIN;
+
+function ghFetch(path: string, init?: RequestInit) {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${GITHUB_TOKEN}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  if (init?.headers) {
+    const provided = init.headers as Record<string, string>;
+    Object.assign(headers, provided);
+  }
+  return fetch(`https://api.github.com/repos/${REPO}${path}`, { ...init, headers });
+}
+
+function requirePin(req: Request, res: Response): boolean {
+  const pin = (req.headers["x-roadmap-pin"] as string) || (req.query.pin as string);
+  if (!ROADMAP_PIN) {
+    res.status(500).json({ error: "ROADMAP_PIN not configured" });
+    return false;
+  }
+  if (pin !== ROADMAP_PIN) {
+    res.status(401).json({ error: "Invalid PIN" });
+    return false;
+  }
+  return true;
+}
+
+// GET /api/monitor/roadmap — live status for all items
+router.get("/roadmap", async (req: Request, res: Response) => {
+  if (!requirePin(req, res)) return;
+  if (!GITHUB_TOKEN) return res.status(500).json({ error: "GITHUB_TOKEN not configured" });
+
+  try {
+    const [prsRes, issuesRes] = await Promise.all([
+      ghFetch("/pulls?state=all&per_page=100&sort=created&direction=desc"),
+      ghFetch("/issues?state=all&per_page=100&sort=created&direction=desc"),
+    ]);
+
+    const prs = (prsRes.ok ? await prsRes.json() : []) as any[];
+    const issues = (issuesRes.ok ? await issuesRes.json() : []) as any[];
+
+    const openPrNumbers: number[] = prs
+      .filter((pr) => pr.state === "open")
+      .map((pr) => pr.number);
+
+    const checksMap: Record<number, string> = {};
+    await Promise.all(
+      openPrNumbers.slice(0, 10).map(async (prNum: number) => {
+        const pr = prs.find((p) => p.number === prNum);
+        if (!pr?.head?.sha) return;
+        const checksRes = await ghFetch(`/commits/${pr.head.sha}/check-runs`);
+        if (checksRes.ok) {
+          const data: any = await checksRes.json();
+          const runs: any[] = data.check_runs || [];
+          if (runs.length === 0) checksMap[prNum] = "pending";
+          else if (runs.every((r) => r.conclusion === "success")) checksMap[prNum] = "success";
+          else if (runs.some((r) => r.conclusion === "failure")) checksMap[prNum] = "failure";
+          else checksMap[prNum] = "in_progress";
+        }
+      }),
+    );
+
+    return res.json({ prs, issues, checks: checksMap });
+  } catch (err) {
+    logger.error("Failed to fetch monitor data", { err });
+    return res.status(500).json({ error: "Failed to fetch GitHub data" });
+  }
+});
+
+// POST /api/monitor/kickoff — create branch + draft PR + dispatch workflow
+router.post("/kickoff", async (req: Request, res: Response) => {
+  if (!requirePin(req, res)) return;
+  if (!GITHUB_TOKEN) return res.status(500).json({ error: "GITHUB_TOKEN not configured" });
+
+  const { itemId, title, description, branch, issueNumber } = req.body;
+  if (!itemId || !title || !branch) {
+    return res.status(400).json({ error: "Missing required fields: itemId, title, branch" });
+  }
+
+  try {
+    // 1. Get main branch SHA
+    const mainRef = await ghFetch("/git/ref/heads/main");
+    if (!mainRef.ok) return res.status(500).json({ error: "Failed to get main branch" });
+    const mainData: any = await mainRef.json();
+    const sha: string = mainData.object.sha;
+
+    // 2. Create branch (422 = already exists, which is fine)
+    const branchRes = await ghFetch("/git/refs", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ref: `refs/heads/${branch}`, sha }),
+    });
+
+    if (!branchRes.ok && branchRes.status !== 422) {
+      return res.status(500).json({ error: "Failed to create branch" });
+    }
+
+    // 3. Create draft PR
+    const prRes = await ghFetch("/pulls", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: `feat(${itemId}): ${title}`,
+        head: branch,
+        base: "main",
+        body: [
+          `## Roadmap Item ${itemId}`,
+          "",
+          description || title,
+          "",
+          issueNumber ? `Closes #${issueNumber}` : "",
+          "",
+          "---",
+          "_Automated by BuildBase Roadmap Monitor_",
+        ].join("\n"),
+        draft: true,
+      }),
+    });
+
+    let prNumber: number | undefined;
+    if (prRes.ok) {
+      const prData: any = await prRes.json();
+      prNumber = prData.number;
+    } else if (prRes.status === 422) {
+      const existingRes = await ghFetch(`/pulls?head=omerskywalker:${branch}&state=open`);
+      if (existingRes.ok) {
+        const existing = (await existingRes.json()) as any[];
+        if (existing.length > 0) prNumber = existing[0].number;
+      }
+    }
+
+    // 4. Dispatch workflow
+    const dispatchRes = await ghFetch("/actions/workflows/claude-feature.yml/dispatches", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        ref: "main",
+        inputs: {
+          item_id: itemId,
+          item_title: title,
+          item_description: description || title,
+          branch_name: branch,
+          issue_number: issueNumber?.toString() ?? "",
+          pr_number: prNumber?.toString() ?? "",
+        },
+      }),
+    });
+
+    if (!dispatchRes.ok && dispatchRes.status !== 204) {
+      const errBody = await dispatchRes.text();
+      logger.error("Workflow dispatch failed", { status: dispatchRes.status, body: errBody });
+      return res.status(500).json({ error: "Workflow dispatch failed" });
+    }
+
+    return res.json({ success: true, branch, pr: prNumber, dispatched: true });
+  } catch (err) {
+    logger.error("Kickoff failed", { err, itemId });
+    return res.status(500).json({ error: "Kickoff failed" });
+  }
+});
+
+// POST /api/monitor/kickoff-batch — dispatch multiple items in parallel
+router.post("/kickoff-batch", async (req: Request, res: Response) => {
+  if (!requirePin(req, res)) return;
+  if (!GITHUB_TOKEN) return res.status(500).json({ error: "GITHUB_TOKEN not configured" });
+
+  const { items } = req.body;
+  if (!Array.isArray(items) || items.length === 0) {
+    return res.status(400).json({ error: "Missing items array" });
+  }
+
+  const port = process.env.PORT ?? 3001;
+  const results = await Promise.allSettled(
+    items.map(async (item: Record<string, unknown>) => {
+      const kickoffRes = await fetch(`http://localhost:${port}/api/monitor/kickoff`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-roadmap-pin": ROADMAP_PIN!,
+        },
+        body: JSON.stringify(item),
+      });
+      const data = (await kickoffRes.json()) as Record<string, unknown>;
+      return { itemId: item.itemId, ...data };
+    }),
+  );
+
+  const succeeded = results
+    .filter((r) => r.status === "fulfilled")
+    .map((r) => (r as PromiseFulfilledResult<Record<string, unknown>>).value);
+  const failed = results
+    .filter((r) => r.status === "rejected")
+    .map((r) => (r as PromiseRejectedResult).reason);
+
+  return res.status(failed.length > 0 ? 207 : 200).json({ succeeded, failed });
+});
+
+// POST /api/monitor/fail — called by workflow on failure
+router.post("/fail", async (req: Request, res: Response) => {
+  const auth = (req.headers.authorization as string)?.replace("Bearer ", "");
+  if (auth !== ROADMAP_PIN) return res.status(401).json({ error: "Unauthorized" });
+
+  const { itemId } = req.body;
+  logger.warn("Roadmap item failed", { itemId });
+  return res.json({ ok: true });
+});
+
+export default router;

--- a/artifacts/buildbase/src/App.tsx
+++ b/artifacts/buildbase/src/App.tsx
@@ -26,6 +26,7 @@ import PlaybookPage from "@/pages/coach/PlaybookPage";
 
 import AdminUsersPage from "@/pages/admin/AdminUsersPage";
 import AdminProgramsPage from "@/pages/admin/AdminProgramsPage";
+import RoadmapMonitor from "@/pages/monitor/RoadmapMonitor";
 
 const queryClient = new QueryClient();
 
@@ -109,6 +110,8 @@ function AppRouter() {
       <Route path="/admin/programs">
         <ProtectedRoute component={AdminProgramsPage} roles={["admin"]} />
       </Route>
+
+      <Route path="/monitor/roadmap" component={RoadmapMonitor} />
 
       <Route>
         <Redirect to="/dashboard" />

--- a/artifacts/buildbase/src/pages/monitor/RoadmapMonitor.tsx
+++ b/artifacts/buildbase/src/pages/monitor/RoadmapMonitor.tsx
@@ -1,0 +1,425 @@
+import { useState, useEffect, useCallback } from "react";
+import { toast } from "sonner";
+
+type ItemStatus = "not-started" | "in-progress" | "done" | "paused" | "failed";
+
+interface RoadmapItem {
+  id: string;
+  title: string;
+  description: string;
+  status: ItemStatus;
+  tests: boolean;
+  branch?: string;
+  pr?: number;
+  issue?: number;
+}
+
+interface RoadmapBatch {
+  number: number;
+  title: string;
+  summary: string;
+  parallelizable: boolean;
+  items: RoadmapItem[];
+}
+
+// Inline roadmap data so the monitor page is self-contained and always current
+const ROADMAP: RoadmapBatch[] = [
+  {
+    number: 1, title: "Stop Lying to Users", summary: "Fix critical bugs that silently lose workout data and show false success messages.", parallelizable: false,
+    items: [
+      { id: "1-1", title: "Fix quick-log persistence — NOT NULL constraint", description: "session_logs.week_number and session_number are NOT NULL but quick-log sends neither.", status: "not-started", tests: true, branch: "fix/quick-log-persistence", issue: 97 },
+      { id: "1-2", title: "Fix QuickLogModal false success on save failure", description: "Catch block sets setSaved(true) even on failure.", status: "not-started", tests: true, branch: "fix/quick-log-false-success", issue: 98 },
+      { id: "1-3", title: "Add apiFetchJson wrapper", description: "Surface API failures as toasts instead of silence.", status: "not-started", tests: true, branch: "fix/api-error-handling", issue: 99 },
+    ],
+  },
+  {
+    number: 2, title: "Backend Hardening", summary: "Stop leaking errors, validate inputs, lock down CORS, use the logger.", parallelizable: true,
+    items: [
+      { id: "2-1", title: "Stop leaking DB error messages", description: "sessions.ts returns raw error.message from Supabase.", status: "not-started", tests: true, branch: "fix/sanitize-error-responses", issue: 100 },
+      { id: "2-2", title: "Verify update row counts", description: "Silent no-ops on session mutations.", status: "not-started", tests: true, branch: "fix/verify-update-row-counts", issue: 101 },
+      { id: "2-3", title: "JSON body size limit + CORS lockdown", description: "No size limit, CORS allows all origins.", status: "not-started", tests: true, branch: "fix/request-limits-cors", issue: 102 },
+      { id: "2-4", title: "Use logger in all route files", description: "Logger exists but is never imported.", status: "not-started", tests: false, branch: "fix/add-server-logging", issue: 115 },
+      { id: "2-5", title: "RLS INSERT policy for form assessments", description: "Missing INSERT WITH CHECK policy.", status: "not-started", tests: false, branch: "fix/form-assessment-rls", issue: 120 },
+    ],
+  },
+  {
+    number: 3, title: "Data Quality & Resilience", summary: "Input validation, seed data fixes, transaction safety, error boundaries.", parallelizable: true,
+    items: [
+      { id: "3-1", title: "Input validation on admin routes", description: "No length/range/URL validation.", status: "not-started", tests: true, branch: "fix/input-validation", issue: 103 },
+      { id: "3-2", title: "Fix seed data weights", description: "Female post-baseline weights are 0, plank reps are 0.", status: "not-started", tests: false, branch: "fix/seed-data-weights", issue: 117 },
+      { id: "3-3", title: "Exercise reorder transaction safety", description: "Promise.all without rollback.", status: "not-started", tests: true, branch: "fix/exercise-reorder-transaction", issue: 116 },
+      { id: "3-4", title: "Error boundaries in React", description: "No error boundaries — white screen on crash.", status: "not-started", tests: true, branch: "feat/error-boundaries", issue: 119 },
+    ],
+  },
+  {
+    number: 4, title: "Core Loop Features", summary: "Enrollment UI, onboarding flow, playbook, session history, exercise videos.", parallelizable: true,
+    items: [
+      { id: "4-1", title: "Program enrollment UI", description: "Assign Program button on admin user detail.", status: "not-started", tests: true, branch: "feat/program-enrollment-ui", issue: 106 },
+      { id: "4-2", title: "Post-onboarding enrollment flow", description: "Auto-enroll or prompt after onboarding.", status: "not-started", tests: true, branch: "feat/post-onboarding-enrollment", issue: 107 },
+      { id: "4-3", title: "Database-backed playbook", description: "Replace hardcoded PLAYBOOK constant.", status: "not-started", tests: true, branch: "feat/playbook-database", issue: 108 },
+      { id: "4-4", title: "Session history view", description: "Browse past workouts with sets/reps/weight.", status: "not-started", tests: true, branch: "feat/session-history", issue: 110 },
+      { id: "4-5", title: "Exercise video/demo links", description: "Render video_url in session cards.", status: "not-started", tests: true, branch: "feat/exercise-video-links", issue: 109 },
+    ],
+  },
+  {
+    number: 5, title: "Code Cleanup", summary: "Decompose oversized components, remove unused packages, add indexes.", parallelizable: true,
+    items: [
+      { id: "5-1", title: "Decompose QuickLogModal", description: "613 lines → 7 focused files.", status: "not-started", tests: true, branch: "refactor/quick-log-decompose", issue: 104 },
+      { id: "5-2", title: "Remove unused Drizzle/generated client", description: "Empty schema, unused packages.", status: "not-started", tests: false, branch: "cleanup/drizzle-decision", issue: 118 },
+      { id: "5-3", title: "Add database indexes", description: "Missing FK and compound indexes.", status: "not-started", tests: false, branch: "perf/add-database-indexes", issue: 105 },
+    ],
+  },
+  {
+    number: 6, title: "Platform Feel", summary: "Email notifications, admin analytics, CI/CD, Stripe.", parallelizable: true,
+    items: [
+      { id: "6-1", title: "Coach note email notifications", description: "Email on coach_notes INSERT.", status: "not-started", tests: true, branch: "feat/coach-note-emails", issue: 111 },
+      { id: "6-2", title: "Admin analytics dashboard", description: "Active athletes, completion rates, coach workload.", status: "not-started", tests: true, branch: "feat/admin-analytics", issue: 112 },
+      { id: "6-3", title: "CI/CD pipeline", description: "Typecheck on push, auto-deploy.", status: "not-started", tests: false, branch: "infra/ci-cd-pipeline", issue: 113 },
+      { id: "6-4", title: "Stripe payments", description: "Subscription billing.", status: "not-started", tests: true, branch: "feat/stripe-payments", issue: 114 },
+    ],
+  },
+];
+
+const REPO = "omerskywalker/BuildBase";
+
+const STATUS_COLORS: Record<ItemStatus, string> = {
+  "not-started": "#988A78",
+  "in-progress": "#C08030",
+  done: "#2D7A3A",
+  paused: "#6B5A48",
+  failed: "#B83020",
+};
+
+const STATUS_LABELS: Record<ItemStatus, string> = {
+  "not-started": "Not Started",
+  "in-progress": "In Progress",
+  done: "Done",
+  paused: "Paused",
+  failed: "Failed",
+};
+
+interface GitHubData {
+  prs: any[];
+  issues: any[];
+  checks: Record<number, string>;
+}
+
+export default function RoadmapMonitor() {
+  const [pin, setPin] = useState("");
+  const [authed, setAuthed] = useState(false);
+  const [pinInput, setPinInput] = useState("");
+  const [ghData, setGhData] = useState<GitHubData | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [kickingOff, setKickingOff] = useState<string | null>(null);
+
+  const fetchStatus = useCallback(async () => {
+    if (!pin) return;
+    try {
+      const res = await fetch(`/api/monitor/roadmap?pin=${pin}`);
+      if (res.ok) {
+        setGhData(await res.json());
+      }
+    } catch {
+      // silent — poll will retry
+    }
+  }, [pin]);
+
+  useEffect(() => {
+    if (!authed) return;
+    fetchStatus();
+    const interval = setInterval(fetchStatus, 30_000);
+    return () => clearInterval(interval);
+  }, [authed, fetchStatus]);
+
+  const handleLogin = () => {
+    setPin(pinInput);
+    setAuthed(true);
+  };
+
+  const getLiveStatus = (item: RoadmapItem): ItemStatus => {
+    if (!ghData || !item.pr) return item.status;
+    const pr = ghData.prs.find((p: any) => p.number === item.pr);
+    if (!pr) return item.status;
+    if (pr.merged_at) return "done";
+    if (pr.state === "closed") return "failed";
+    const check = ghData.checks[item.pr];
+    if (check === "failure") return "failed";
+    if (check === "in_progress" || check === "pending") return "in-progress";
+    if (pr.state === "open") return "in-progress";
+    return item.status;
+  };
+
+  const kickoff = async (item: RoadmapItem) => {
+    setKickingOff(item.id);
+    try {
+      const res = await fetch("/api/monitor/kickoff", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "x-roadmap-pin": pin },
+        body: JSON.stringify({
+          itemId: item.id,
+          title: item.title,
+          description: item.description,
+          branch: item.branch,
+          issueNumber: item.issue,
+        }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        toast.success(`Started ${item.id}: ${item.title}`, {
+          description: data.pr ? `PR #${data.pr} created` : "Workflow dispatched",
+        });
+        fetchStatus();
+      } else {
+        toast.error(`Failed to start ${item.id}`, { description: data.error });
+      }
+    } catch {
+      toast.error(`Failed to start ${item.id}`);
+    } finally {
+      setKickingOff(null);
+    }
+  };
+
+  const kickoffBatch = async (batch: RoadmapBatch) => {
+    const notStarted = batch.items.filter((i) => getLiveStatus(i) === "not-started");
+    if (notStarted.length === 0) {
+      toast.info("No items to start in this batch");
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await fetch("/api/monitor/kickoff-batch", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "x-roadmap-pin": pin },
+        body: JSON.stringify({
+          items: notStarted.map((i) => ({
+            itemId: i.id,
+            title: i.title,
+            description: i.description,
+            branch: i.branch,
+            issueNumber: i.issue,
+          })),
+        }),
+      });
+      const data = await res.json();
+      toast.success(`Dispatched ${data.succeeded?.length ?? 0} items`, {
+        description: data.failed?.length ? `${data.failed.length} failed` : undefined,
+      });
+      fetchStatus();
+    } catch {
+      toast.error("Batch kickoff failed");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!authed) {
+    return (
+      <div style={{ background: "#EDE4D3", minHeight: "100vh", display: "flex", alignItems: "center", justifyContent: "center" }}>
+        <div style={{ background: "#E8DECE", border: "1px solid #C8B99D", borderRadius: 12, padding: 32, width: 360, textAlign: "center" }}>
+          <h1 style={{ color: "#2C1A10", fontSize: 24, marginBottom: 8 }}>
+            <span style={{ color: "#1C3A2A" }}>Build</span>
+            <span style={{ color: "#C84B1A", fontWeight: 700 }}>Base</span>
+            {" "}Monitor
+          </h1>
+          <p style={{ color: "#6B5A48", marginBottom: 24 }}>Enter PIN to access the roadmap</p>
+          <input
+            type="password"
+            value={pinInput}
+            onChange={(e) => setPinInput(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && handleLogin()}
+            placeholder="PIN"
+            style={{
+              width: "100%", padding: "10px 16px", border: "1px solid #C8B99D", borderRadius: 8,
+              background: "#FAF6F0", color: "#2C1A10", fontSize: 16, marginBottom: 16, outline: "none",
+              boxSizing: "border-box",
+            }}
+          />
+          <button
+            onClick={handleLogin}
+            style={{
+              width: "100%", padding: "10px 16px", background: "#C84B1A", color: "#FEFCF8",
+              border: "none", borderRadius: 8, fontSize: 16, fontWeight: 600, cursor: "pointer",
+            }}
+          >
+            Enter
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const allItems = ROADMAP.flatMap((b) => b.items);
+  const doneCount = allItems.filter((i) => getLiveStatus(i) === "done").length;
+  const pct = Math.round((doneCount / allItems.length) * 100);
+
+  return (
+    <div style={{ background: "#EDE4D3", minHeight: "100vh", padding: "32px 16px" }}>
+      <div style={{ maxWidth: 900, margin: "0 auto" }}>
+        {/* Header */}
+        <div style={{ marginBottom: 32 }}>
+          <h1 style={{ color: "#2C1A10", fontSize: 28, marginBottom: 4 }}>
+            <span style={{ color: "#1C3A2A" }}>Build</span>
+            <span style={{ color: "#C84B1A", fontWeight: 700 }}>Base</span>
+            {" "}Roadmap V2
+          </h1>
+          <p style={{ color: "#6B5A48", margin: 0 }}>
+            {doneCount}/{allItems.length} items complete ({pct}%)
+          </p>
+          {/* Progress bar */}
+          <div style={{ marginTop: 12, height: 8, background: "#DDD2BF", borderRadius: 4, overflow: "hidden" }}>
+            <div style={{ height: "100%", width: `${pct}%`, background: "#2D7A3A", borderRadius: 4, transition: "width 0.3s" }} />
+          </div>
+        </div>
+
+        {/* Batches */}
+        {ROADMAP.map((batch) => {
+          const batchDone = batch.items.filter((i) => getLiveStatus(i) === "done").length;
+          const batchPct = Math.round((batchDone / batch.items.length) * 100);
+          const allDone = batchDone === batch.items.length;
+          const hasNotStarted = batch.items.some((i) => getLiveStatus(i) === "not-started");
+
+          return (
+            <div key={batch.number} style={{
+              background: "#E8DECE", border: "1px solid #C8B99D", borderRadius: 12,
+              padding: 24, marginBottom: 20,
+            }}>
+              {/* Batch header */}
+              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", marginBottom: 12 }}>
+                <div>
+                  <h2 style={{ color: "#2C1A10", fontSize: 18, margin: 0 }}>
+                    Phase {batch.number}: {batch.title}
+                    {allDone && " ✓"}
+                  </h2>
+                  <p style={{ color: "#6B5A48", fontSize: 14, margin: "4px 0 0" }}>{batch.summary}</p>
+                  <div style={{ display: "flex", gap: 8, marginTop: 6 }}>
+                    <span style={{ fontSize: 12, color: "#988A78" }}>{batchDone}/{batch.items.length} ({batchPct}%)</span>
+                    {batch.parallelizable && (
+                      <span style={{ fontSize: 11, color: "#1C3A2A", background: "#1C3A2A18", padding: "2px 8px", borderRadius: 4 }}>
+                        Parallelizable
+                      </span>
+                    )}
+                  </div>
+                </div>
+                {batch.parallelizable && hasNotStarted && (
+                  <button
+                    onClick={() => kickoffBatch(batch)}
+                    disabled={loading}
+                    style={{
+                      padding: "6px 16px", background: "#1C3A2A", color: "#FEFCF8",
+                      border: "none", borderRadius: 6, fontSize: 13, fontWeight: 600,
+                      cursor: loading ? "wait" : "pointer", opacity: loading ? 0.6 : 1,
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    Start All
+                  </button>
+                )}
+              </div>
+
+              {/* Batch progress bar */}
+              <div style={{ height: 4, background: "#DDD2BF", borderRadius: 2, marginBottom: 16, overflow: "hidden" }}>
+                <div style={{ height: "100%", width: `${batchPct}%`, background: "#2D7A3A", borderRadius: 2, transition: "width 0.3s" }} />
+              </div>
+
+              {/* Items */}
+              {batch.items.map((item) => {
+                const liveStatus = getLiveStatus(item);
+                const isKicking = kickingOff === item.id;
+
+                return (
+                  <div key={item.id} style={{
+                    display: "flex", alignItems: "center", gap: 12,
+                    padding: "10px 14px", background: "#FAF6F0", border: "1px solid #DDD2BF",
+                    borderRadius: 8, marginBottom: 8,
+                  }}>
+                    {/* Status badge */}
+                    <span style={{
+                      display: "inline-block", width: 10, height: 10, borderRadius: "50%",
+                      background: STATUS_COLORS[liveStatus], flexShrink: 0,
+                      animation: liveStatus === "in-progress" ? "pulse 2s infinite" : undefined,
+                    }} />
+
+                    {/* Item info */}
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                        <span style={{ color: "#988A78", fontSize: 13, fontWeight: 600 }}>{item.id}</span>
+                        <span style={{ color: "#2C1A10", fontSize: 14, fontWeight: 500 }}>{item.title}</span>
+                      </div>
+                      <div style={{ display: "flex", gap: 8, marginTop: 4 }}>
+                        <span style={{
+                          fontSize: 11, color: STATUS_COLORS[liveStatus],
+                          background: `${STATUS_COLORS[liveStatus]}18`, padding: "1px 6px", borderRadius: 3,
+                        }}>
+                          {STATUS_LABELS[liveStatus]}
+                        </span>
+                        {item.issue && (
+                          <a
+                            href={`https://github.com/${REPO}/issues/${item.issue}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            style={{ fontSize: 11, color: "#6B5A48", textDecoration: "none" }}
+                          >
+                            #{item.issue}
+                          </a>
+                        )}
+                        {item.pr && (
+                          <a
+                            href={`https://github.com/${REPO}/pull/${item.pr}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            style={{ fontSize: 11, color: "#6B5A48", textDecoration: "none" }}
+                          >
+                            PR #{item.pr}
+                          </a>
+                        )}
+                        {item.tests && <span style={{ fontSize: 11, color: "#988A78" }}>tests required</span>}
+                      </div>
+                    </div>
+
+                    {/* Action button */}
+                    {liveStatus === "not-started" && (
+                      <button
+                        onClick={() => kickoff(item)}
+                        disabled={isKicking}
+                        style={{
+                          padding: "5px 14px", background: "#C84B1A", color: "#FEFCF8",
+                          border: "none", borderRadius: 6, fontSize: 13, fontWeight: 600,
+                          cursor: isKicking ? "wait" : "pointer", opacity: isKicking ? 0.6 : 1,
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        {isKicking ? "Starting..." : "Start"}
+                      </button>
+                    )}
+                    {liveStatus === "failed" && (
+                      <button
+                        onClick={() => kickoff(item)}
+                        disabled={isKicking}
+                        style={{
+                          padding: "5px 14px", background: "#B83020", color: "#FEFCF8",
+                          border: "none", borderRadius: 6, fontSize: 13, fontWeight: 600,
+                          cursor: isKicking ? "wait" : "pointer", opacity: isKicking ? 0.6 : 1,
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        {isKicking ? "Retrying..." : "Retry"}
+                      </button>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          );
+        })}
+
+        {/* Pulse animation */}
+        <style>{`
+          @keyframes pulse {
+            0%, 100% { opacity: 1; }
+            50% { opacity: 0.4; }
+          }
+        `}</style>
+      </div>
+    </div>
+  );
+}

--- a/lib/roadmap-data.ts
+++ b/lib/roadmap-data.ts
@@ -1,0 +1,619 @@
+export type ItemStatus = "not-started" | "in-progress" | "done" | "paused" | "failed";
+
+export interface ItemScope {
+  owns: string[];
+  avoid: string[];
+}
+
+export interface RoadmapItem {
+  id: string;
+  title: string;
+  description: string;
+  status: ItemStatus;
+  tests: boolean;
+  branch?: string;
+  pr?: number;
+  issue?: number;
+  scope?: ItemScope;
+}
+
+export interface RoadmapBatch {
+  number: number;
+  title: string;
+  summary: string;
+  parallelizable: boolean;
+  items: RoadmapItem[];
+}
+
+export const REPO = process.env.NEXT_PUBLIC_GITHUB_REPO ?? "omerskywalker/BuildBase";
+
+export const ROADMAP: RoadmapBatch[] = [
+  // ── Phase 1: Stop Lying to Users ──────────────────────────────────────────
+  // Critical bugs that cause data loss or false feedback. Do these first, sequentially.
+  {
+    number: 1,
+    title: "Stop Lying to Users",
+    summary: "Fix the critical bugs that silently lose workout data and show false success messages.",
+    parallelizable: false,
+    items: [
+      {
+        id: "1-1",
+        title: "Fix quick-log persistence — session_logs NOT NULL constraint",
+        description: [
+          "session_logs.week_number and session_number are NOT NULL but the quick-log API sends neither.",
+          "Add a migration: ALTER TABLE session_logs ALTER COLUMN week_number SET DEFAULT 0; same for session_number.",
+          "Verify the quick-log route (artifacts/api-server/src/routes/quick-log.ts) inserts successfully after the migration.",
+          "Add a test that POSTs to /api/quick-log and asserts the session_log row exists with week_number=0.",
+        ].join("\n"),
+        status: "not-started",
+        tests: true,
+        branch: "fix/quick-log-persistence",
+        issue: 97,
+        scope: {
+          owns: [
+            "supabase/migrations/004_quick_log_defaults.sql",
+            "artifacts/api-server/src/routes/quick-log.ts",
+          ],
+          avoid: ["artifacts/buildbase/src/components/QuickLogModal.tsx"],
+        },
+      },
+      {
+        id: "1-2",
+        title: "Fix QuickLogModal false success on save failure",
+        description: [
+          "QuickLogModal.tsx:560-562 catch block sets setSaved(true) even on failure — user sees 'Workout Saved!' when nothing was recorded.",
+          "Also line 548-549 never checks response.ok.",
+          "Fix: check response.ok after fetch, throw on non-2xx. In catch block, show toast.error() instead of setSaved(true). Keep modal open for retry.",
+          "Depends on #97 being merged first (otherwise all quick-logs fail).",
+          "Add a test that mocks a failed API response and asserts the error toast appears.",
+        ].join("\n"),
+        status: "not-started",
+        tests: true,
+        branch: "fix/quick-log-false-success",
+        issue: 98,
+        scope: {
+          owns: ["artifacts/buildbase/src/components/QuickLogModal.tsx"],
+          avoid: ["artifacts/api-server/src/routes/quick-log.ts"],
+        },
+      },
+      {
+        id: "1-3",
+        title: "Add apiFetchJson wrapper — surface API failures as toasts",
+        description: [
+          "apiFetch() in artifacts/buildbase/src/lib/api.ts returns raw Response. 6+ callers skip response.ok check.",
+          "Create apiFetchJson<T>() that checks .ok, parses JSON, and throws ApiError on failure.",
+          "Migrate all callers that currently do .then(r => r.json()) without checking .ok:",
+          "  CoachNotesPage, MilestonesPage, TrendsPage, ProgressPage, ChartsPage, ClientsPage,",
+          "  SorenessPrompt, EffortPrompt, SessionCard (fire-and-forget calls).",
+          "Each migrated caller should catch and show toast.error().",
+          "Add tests for the apiFetchJson wrapper (success path, error path, network failure).",
+        ].join("\n"),
+        status: "not-started",
+        tests: true,
+        branch: "fix/api-error-handling",
+        issue: 99,
+        scope: {
+          owns: ["artifacts/buildbase/src/lib/api.ts"],
+          avoid: ["artifacts/api-server/"],
+        },
+      },
+    ],
+  },
+
+  // ── Phase 2: Backend Hardening ────────────────────────────────────────────
+  // Security and reliability fixes on the Express API. Most touch separate route files.
+  {
+    number: 2,
+    title: "Backend Hardening",
+    summary: "Stop leaking errors, validate inputs, lock down CORS, and actually use the logger.",
+    parallelizable: true,
+    items: [
+      {
+        id: "2-1",
+        title: "Stop leaking database error messages to clients",
+        description: [
+          "sessions.ts returns raw error.message from Supabase in 7 places (lines 144, 166, 187, 226, 304, 329, 354).",
+          "This exposes table names, column names, and constraint names to clients.",
+          "Replace all error.message responses with generic messages.",
+          "Import logger from ../lib/logger.ts (currently never imported in ANY route file) and log the actual error server-side.",
+          "Standardize error response shape: { error: string } across all routes.",
+        ].join("\n"),
+        status: "not-started",
+        tests: true,
+        branch: "fix/sanitize-error-responses",
+        issue: 100,
+        scope: {
+          owns: ["artifacts/api-server/src/routes/sessions.ts"],
+          avoid: [
+            "artifacts/api-server/src/routes/admin.ts",
+            "artifacts/api-server/src/routes/coach.ts",
+            "artifacts/api-server/src/routes/quick-log.ts",
+          ],
+        },
+      },
+      {
+        id: "2-2",
+        title: "Verify update row counts — silent no-ops on sessions",
+        description: [
+          "POST /sessions/:id/complete, /effort, /soreness check for Supabase errors but don't verify the update affected rows.",
+          "If target row doesn't exist (wrong ID, RLS blocks), response is { ok: true } — a silent no-op.",
+          "Also DELETE /admin/users doesn't confirm update succeeded.",
+          "Fix: use .select('id').single() after .update() and check returned data.",
+          "Return 404 if no rows affected.",
+        ].join("\n"),
+        status: "not-started",
+        tests: true,
+        branch: "fix/verify-update-row-counts",
+        issue: 101,
+        scope: {
+          owns: [
+            "artifacts/api-server/src/routes/sessions.ts",
+            "artifacts/api-server/src/routes/admin.ts",
+          ],
+          avoid: ["artifacts/api-server/src/routes/coach.ts"],
+        },
+      },
+      {
+        id: "2-3",
+        title: "Add JSON body size limit and CORS origin allowlist",
+        description: [
+          "app.ts uses express.json() with no limit option — attacker can send multi-GB payload.",
+          "cors() uses default config (allows all origins).",
+          "Fix: express.json({ limit: '1mb' }), cors({ origin: process.env.FRONTEND_URL, credentials: true }).",
+        ].join("\n"),
+        status: "not-started",
+        tests: true,
+        branch: "fix/request-limits-cors",
+        issue: 102,
+        scope: {
+          owns: ["artifacts/api-server/src/app.ts"],
+          avoid: ["artifacts/api-server/src/routes/"],
+        },
+      },
+      {
+        id: "2-4",
+        title: "Use logger in all route files",
+        description: [
+          "lib/logger.ts exists and is properly defined but is NEVER imported in any route file.",
+          "All server-side errors are silently returned to clients without being logged.",
+          "Import and use logger in every route file for error cases and key operations.",
+          "This is a cross-cutting change — touch all route files.",
+        ].join("\n"),
+        status: "not-started",
+        tests: false,
+        branch: "fix/add-server-logging",
+        issue: 115,
+        scope: {
+          owns: [
+            "artifacts/api-server/src/routes/admin.ts",
+            "artifacts/api-server/src/routes/coach.ts",
+            "artifacts/api-server/src/routes/dashboard.ts",
+            "artifacts/api-server/src/routes/progress.ts",
+            "artifacts/api-server/src/routes/quick-log.ts",
+          ],
+          avoid: [],
+        },
+      },
+      {
+        id: "2-5",
+        title: "Add RLS INSERT policy for coach_form_assessments",
+        description: [
+          "schema.sql:412-416 defines SELECT/ALL policies for coach_form_assessments but no explicit INSERT WITH CHECK.",
+          "Coaches may be unable to insert new form assessments.",
+          "Add migration with: CREATE POLICY form_assessments_coach_insert ON coach_form_assessments FOR INSERT WITH CHECK (coach_id = auth.uid());",
+        ].join("\n"),
+        status: "not-started",
+        tests: false,
+        branch: "fix/form-assessment-rls",
+        issue: 120,
+        scope: {
+          owns: ["supabase/migrations/005_form_assessment_rls.sql"],
+          avoid: [],
+        },
+      },
+    ],
+  },
+
+  // ── Phase 3: Data Quality & Resilience ────────────────────────────────────
+  {
+    number: 3,
+    title: "Data Quality & Resilience",
+    summary: "Input validation, seed data fixes, transaction safety, and React error boundaries.",
+    parallelizable: true,
+    items: [
+      {
+        id: "3-1",
+        title: "Validate input on admin exercise/user creation routes",
+        description: [
+          "No length limits on text fields (exercise names, descriptions, coaching cues).",
+          "No range validation on numeric inputs (reps_completed, weight_used accept negatives).",
+          "No URL format validation on video_url (could accept javascript: URIs).",
+          "Search string unbounded in admin.ts:470.",
+          "Add Zod validation (api-zod package already exists in workspace).",
+        ].join("\n"),
+        status: "not-started",
+        tests: true,
+        branch: "fix/input-validation",
+        issue: 103,
+        scope: {
+          owns: [
+            "artifacts/api-server/src/routes/admin.ts",
+            "artifacts/api-server/src/routes/sessions.ts",
+          ],
+          avoid: [],
+        },
+      },
+      {
+        id: "3-2",
+        title: "Fix seed data: weights and plank reps",
+        description: [
+          "Female post-baseline weights set to 0 — athletes who complete baseline would see weights drop to 0.",
+          "Plank has reps_default=0 (time hold), UI shows '0 reps'.",
+          "Phase 3 deadlift starts at 65 lbs (f) but Phase 1 trap bar deadlift starts at 45 — backwards progression.",
+          "Fix all weight values for logical progression across phases.",
+        ].join("\n"),
+        status: "not-started",
+        tests: false,
+        branch: "fix/seed-data-weights",
+        issue: 117,
+        scope: {
+          owns: ["supabase/seed.sql"],
+          avoid: [],
+        },
+      },
+      {
+        id: "3-3",
+        title: "Exercise reorder: use transaction instead of Promise.all",
+        description: [
+          "admin.ts:443-447 reorders exercises via Promise.all with individual updates.",
+          "If one update fails, partial state is left with no rollback.",
+          "Fix: use a Supabase RPC function that wraps the reorder in a database transaction.",
+          "Or at minimum, catch individual failures and report which ones failed.",
+        ].join("\n"),
+        status: "not-started",
+        tests: true,
+        branch: "fix/exercise-reorder-transaction",
+        issue: 116,
+        scope: {
+          owns: ["artifacts/api-server/src/routes/admin.ts"],
+          avoid: [],
+        },
+      },
+      {
+        id: "3-4",
+        title: "Add error boundaries to React app",
+        description: [
+          "No error boundary components exist. Unhandled errors crash the entire page (white screen).",
+          "Add a root-level ErrorBoundary wrapping the app.",
+          "Add per-page error boundaries for graceful degradation.",
+          "Show 'Something went wrong' UI with retry button.",
+        ].join("\n"),
+        status: "not-started",
+        tests: true,
+        branch: "feat/error-boundaries",
+        issue: 119,
+        scope: {
+          owns: [
+            "artifacts/buildbase/src/components/ErrorBoundary.tsx",
+            "artifacts/buildbase/src/App.tsx",
+          ],
+          avoid: [],
+        },
+      },
+    ],
+  },
+
+  // ── Phase 4: Core Loop Features ───────────────────────────────────────────
+  // Features that complete the core product loop. Parallelizable with scope contracts.
+  {
+    number: 4,
+    title: "Core Loop Features",
+    summary: "Program enrollment, post-onboarding flow, database-backed playbook, session history, and exercise videos.",
+    parallelizable: true,
+    items: [
+      {
+        id: "4-1",
+        title: "Program enrollment UI — Assign Program button",
+        description: [
+          "Admins currently must touch the database to enroll athletes into programs.",
+          "Add 'Assign Program' button to AdminUsersPage with program dropdown.",
+          "New endpoint: POST /api/admin/enroll { userId, programId }.",
+          "Deactivates any current enrollment, creates new user_enrollments row.",
+          "Show confirmation toast.",
+        ].join("\n"),
+        status: "not-started",
+        tests: true,
+        branch: "feat/program-enrollment-ui",
+        issue: 106,
+        scope: {
+          owns: [
+            "artifacts/api-server/src/routes/admin.ts",
+            "artifacts/buildbase/src/pages/admin/AdminUsersPage.tsx",
+          ],
+          avoid: [
+            "artifacts/buildbase/src/pages/DashboardPage.tsx",
+            "artifacts/buildbase/src/pages/OnboardingPage.tsx",
+          ],
+        },
+      },
+      {
+        id: "4-2",
+        title: "Post-onboarding flow — auto-enroll or prompt",
+        description: [
+          "After onboarding, athletes hit a blank dashboard with no sessions or progress.",
+          "Check if user has active enrollment after onboarding completes.",
+          "If not, show 'Getting Started' card on dashboard.",
+          "Handle the no-enrollment state gracefully instead of showing empty sections.",
+        ].join("\n"),
+        status: "not-started",
+        tests: true,
+        branch: "feat/post-onboarding-enrollment",
+        issue: 107,
+        scope: {
+          owns: [
+            "artifacts/buildbase/src/pages/DashboardPage.tsx",
+            "artifacts/buildbase/src/pages/OnboardingPage.tsx",
+          ],
+          avoid: ["artifacts/buildbase/src/pages/admin/"],
+        },
+      },
+      {
+        id: "4-3",
+        title: "Make playbook database-backed",
+        description: [
+          "PlaybookPage.tsx has a static PLAYBOOK constant. Coaches can't add/edit without a code deploy.",
+          "New table: playbook_entries (id, title, category, content, created_by, is_active, order_index, timestamps).",
+          "RLS: coaches/admins can CRUD, athletes can SELECT.",
+          "API endpoints: GET/POST/PUT/DELETE /api/coach/playbook.",
+          "Update PlaybookPage.tsx to fetch from API.",
+          "Add create/edit UI for coaches.",
+        ].join("\n"),
+        status: "not-started",
+        tests: true,
+        branch: "feat/playbook-database",
+        issue: 108,
+        scope: {
+          owns: [
+            "artifacts/buildbase/src/pages/coach/PlaybookPage.tsx",
+            "artifacts/api-server/src/routes/coach.ts",
+            "supabase/migrations/006_playbook_entries.sql",
+          ],
+          avoid: [
+            "artifacts/buildbase/src/pages/sessions/",
+            "artifacts/buildbase/src/pages/admin/",
+          ],
+        },
+      },
+      {
+        id: "4-4",
+        title: "Session history view",
+        description: [
+          "Athletes can see charts but can't browse past workouts.",
+          "New page or tab: session history in reverse chronological order.",
+          "Each entry: date, workout name, exercises with sets/reps/weight.",
+          "Expandable/collapsible detail per session.",
+          "Backend: GET /api/sessions/history?page=1&limit=20 (paginated).",
+        ].join("\n"),
+        status: "not-started",
+        tests: true,
+        branch: "feat/session-history",
+        issue: 110,
+        scope: {
+          owns: [
+            "artifacts/buildbase/src/pages/sessions/SessionHistoryPage.tsx",
+            "artifacts/api-server/src/routes/sessions.ts",
+          ],
+          avoid: [
+            "artifacts/buildbase/src/pages/sessions/SessionsPage.tsx",
+            "artifacts/buildbase/src/pages/sessions/SessionCard.tsx",
+          ],
+        },
+      },
+      {
+        id: "4-5",
+        title: "Render exercise video/demo links in session cards",
+        description: [
+          "video_url column exists on exercises (schema.sql:77) and is typed (types.ts:61) but nothing renders it.",
+          "In SessionCard or SessionDetailModal, if exercise has video_url, render a video icon/link.",
+          "Clicking opens embedded player (YouTube iframe) or external link.",
+          "Add sample video URLs to seed data for key exercises.",
+        ].join("\n"),
+        status: "not-started",
+        tests: true,
+        branch: "feat/exercise-video-links",
+        issue: 109,
+        scope: {
+          owns: [
+            "artifacts/buildbase/src/pages/sessions/SessionCard.tsx",
+            "artifacts/buildbase/src/pages/sessions/SessionDetailModal.tsx",
+          ],
+          avoid: ["artifacts/buildbase/src/pages/sessions/SessionsPage.tsx"],
+        },
+      },
+    ],
+  },
+
+  // ── Phase 5: Code Cleanup ─────────────────────────────────────────────────
+  {
+    number: 5,
+    title: "Code Cleanup",
+    summary: "Decompose oversized components, remove unused packages, add database indexes.",
+    parallelizable: true,
+    items: [
+      {
+        id: "5-1",
+        title: "Decompose QuickLogModal (613 lines)",
+        description: [
+          "QuickLogModal.tsx is 613 lines with step state machine, muscle group selector, exercise cards,",
+          "set row logic, and save orchestration all in one file.",
+          "Split into: QuickLogModal (shell), MuscleGroupStep, ExerciseLogStep,",
+          "QuickLogExerciseCard, QuickLogSetRow, QuickLogSummary, useQuickLogSave hook.",
+          "Place in artifacts/buildbase/src/components/quick-log/ directory.",
+          "Must preserve all existing functionality — this is a pure refactor.",
+        ].join("\n"),
+        status: "not-started",
+        tests: true,
+        branch: "refactor/quick-log-decompose",
+        issue: 104,
+        scope: {
+          owns: [
+            "artifacts/buildbase/src/components/QuickLogModal.tsx",
+            "artifacts/buildbase/src/components/quick-log/",
+          ],
+          avoid: [],
+        },
+      },
+      {
+        id: "5-2",
+        title: "Remove unused Drizzle / generated API client",
+        description: [
+          "lib/db/src/schema/index.ts is completely empty. Drizzle is installed but defines zero tables.",
+          "lib/api-client-react generated client only covers health check — doesn't match actual API.",
+          "lib/api-zod generated types same issue.",
+          "lib/api-spec OpenAPI spec only defines GET /healthz.",
+          "Remove these packages or document the decision to adopt them later.",
+        ].join("\n"),
+        status: "not-started",
+        tests: false,
+        branch: "cleanup/drizzle-decision",
+        issue: 118,
+        scope: {
+          owns: ["lib/db/", "lib/api-client-react/", "lib/api-zod/", "lib/api-spec/"],
+          avoid: [],
+        },
+      },
+      {
+        id: "5-3",
+        title: "Add missing database indexes",
+        description: [
+          "Missing indexes on frequently-joined FK columns and common query patterns.",
+          "Add: idx_template_exercises_exercise_id, idx_set_logs_exercise_id,",
+          "idx_personal_records_exercise_id, idx_user_enrollments_program_id,",
+          "idx_session_logs_user_week, idx_set_logs_session_exercise,",
+          "idx_template_exercises_ordering, idx_form_assessments_user_exercise.",
+          "Also refactor progress.ts .in() fallback to use a subquery instead of passing all session IDs.",
+        ].join("\n"),
+        status: "not-started",
+        tests: false,
+        branch: "perf/add-database-indexes",
+        issue: 105,
+        scope: {
+          owns: [
+            "supabase/migrations/007_add_indexes.sql",
+            "artifacts/api-server/src/routes/progress.ts",
+          ],
+          avoid: [],
+        },
+      },
+    ],
+  },
+
+  // ── Phase 6: Platform Feel ────────────────────────────────────────────────
+  {
+    number: 6,
+    title: "Platform Feel",
+    summary: "Email notifications, admin analytics, CI/CD, and Stripe — the features that make it a real product.",
+    parallelizable: true,
+    items: [
+      {
+        id: "6-1",
+        title: "Coach note email notifications",
+        description: [
+          "Athletes only see notes if they open the app. Email on coach_notes INSERT would drive engagement.",
+          "Supabase Edge Function triggered on INSERT.",
+          "Send via Resend or SendGrid (free tier). Email: coach name, note preview, link to app.",
+          "Add email_notifications preference to profiles (default: on).",
+          "Rate limit: max 1 email per coach per athlete per hour.",
+        ].join("\n"),
+        status: "not-started",
+        tests: true,
+        branch: "feat/coach-note-emails",
+        issue: 111,
+        scope: {
+          owns: ["supabase/functions/notify-coach-note/"],
+          avoid: [],
+        },
+      },
+      {
+        id: "6-2",
+        title: "Admin analytics dashboard",
+        description: [
+          "Admins have zero visibility into platform usage.",
+          "New admin page with: total active athletes, weekly completion rate,",
+          "coach workload (clients/coach, notes/week), new signups.",
+          "Backend: GET /api/admin/analytics aggregation endpoint.",
+          "Charts using Recharts.",
+        ].join("\n"),
+        status: "not-started",
+        tests: true,
+        branch: "feat/admin-analytics",
+        issue: 112,
+        scope: {
+          owns: [
+            "artifacts/buildbase/src/pages/admin/AdminAnalyticsPage.tsx",
+            "artifacts/api-server/src/routes/admin.ts",
+          ],
+          avoid: [],
+        },
+      },
+      {
+        id: "6-3",
+        title: "CI/CD pipeline",
+        description: [
+          "No automated checks on push. Broken types can land on main.",
+          "Create .github/workflows/ci.yml: trigger on push to main and PRs,",
+          "run pnpm install, pnpm run typecheck, pnpm run build.",
+          "Auto-deploy to Vercel on merge to main.",
+          "Add Prettier lint step (already a devDep).",
+        ].join("\n"),
+        status: "not-started",
+        tests: false,
+        branch: "infra/ci-cd-pipeline",
+        issue: 113,
+        scope: {
+          owns: [".github/workflows/ci.yml"],
+          avoid: [".github/workflows/claude-feature.yml"],
+        },
+      },
+      {
+        id: "6-4",
+        title: "Stripe payments — subscription billing",
+        description: [
+          "Subscription layer for coach/athlete billing.",
+          "Stripe integration for recurring subscriptions.",
+          "Webhook handler for subscription lifecycle events.",
+          "Billing portal, invoice history, plan management.",
+          "Requires business model decision first.",
+        ].join("\n"),
+        status: "not-started",
+        tests: true,
+        branch: "feat/stripe-payments",
+        issue: 114,
+        scope: {
+          owns: [
+            "artifacts/api-server/src/routes/billing.ts",
+            "artifacts/buildbase/src/pages/BillingPage.tsx",
+          ],
+          avoid: [],
+        },
+      },
+    ],
+  },
+];
+
+// ── Progress helpers ──────────────────────────────────────────────────────────
+
+export function getBatchProgress(batch: RoadmapBatch) {
+  const total = batch.items.length;
+  const done = batch.items.filter((i) => i.status === "done").length;
+  const inProgress = batch.items.filter((i) => i.status === "in-progress").length;
+  return { total, done, inProgress };
+}
+
+export function getOverallProgress() {
+  const allItems = ROADMAP.flatMap((b) => b.items);
+  const total = allItems.length;
+  const done = allItems.filter((i) => i.status === "done").length;
+  const pct = Math.round((done / total) * 100);
+  return { total, done, pct };
+}


### PR DESCRIPTION
## Summary

- **`lib/roadmap-data.ts`** — 24 roadmap items across 6 phases, matching the V1 monitor format
- **`.github/workflows/claude-feature.yml`** — dispatches Claude Code agent per item with self-healing CI and automated code review before commit
- **`.github/workflows/stamp-done.yml`** — auto-updates roadmap-data.ts status to `done` when PRs merge to main
- **`artifacts/api-server/src/routes/monitor.ts`** — Express API for kickoff (creates branch → draft PR → dispatches workflow), batch kickoff, live status, and failure reporting
- **`artifacts/buildbase/src/pages/monitor/RoadmapMonitor.tsx`** — PIN-gated roadmap dashboard at `/monitor/roadmap` with Start, Retry, and Start All buttons
- **Orchestrator issue #121** (pinned) — agent operating rules, definition of done, phase ordering, scope contracts

## What this enables

After merge, navigate to `/monitor/roadmap`, enter the `ROADMAP_PIN`, and click **Start** on any item. The system will:
1. Create a feature branch from main
2. Open a draft PR
3. Dispatch `claude-feature.yml` which runs Claude Code in agent mode
4. Agent reads the issue spec, implements the change, writes tests
5. Self-heals if typecheck/build fails (second agent pass)
6. Runs a code review pass before committing
7. Pushes, marks PR ready for review
8. On merge, `stamp-done.yml` updates roadmap-data.ts automatically

## Env vars needed

| Var | Where | Status |
|-----|-------|--------|
| `ANTHROPIC_API_KEY` | GitHub Actions secrets | Already set from V1 |
| `GITHUB_TOKEN` | Express server env | Needed for kickoff API — the PAT with repo + workflow scope |
| `ROADMAP_PIN` | Express server env | Needed for monitor auth |

## Test plan

- [ ] Merge this PR
- [ ] Set `GITHUB_TOKEN` and `ROADMAP_PIN` env vars on the Express server
- [ ] Navigate to `/monitor/roadmap` and enter PIN
- [ ] Click Start on item 1-1 and verify the workflow dispatches
- [ ] Verify branch, draft PR, and workflow run appear in GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)