### PR TITLE
feat(9-1): Fix quick-log persistence — session_logs NOT NULL constraint

### DIFF
--- a/lib/roadmap-data.ts
+++ b/lib/roadmap-data.ts
@@ -479,7 +479,7 @@ export const ROADMAP: RoadmapBatch[] = [
           "Verify the quick-log route (app/api/quick-log/route.ts) inserts successfully after the migration.",
           "Add a test that POSTs to /api/quick-log and asserts the session_log row exists with week_number=0.",
         ].join("\n"),
-        status: "not-started",
+        status: "in-progress",
         tests: true,
         branch: "fix/quick-log-persistence",
         issue: 97,

--- a/supabase/migrations/004_quick_log_defaults.sql
+++ b/supabase/migrations/004_quick_log_defaults.sql
@@ -1,0 +1,4 @@
+-- Migration 004: Add default values for session_logs week/session numbers
+-- Fixes NOT NULL constraint violation when quick-log API inserts without these values.
+ALTER TABLE session_logs ALTER COLUMN week_number SET DEFAULT 0;
+ALTER TABLE session_logs ALTER COLUMN session_number SET DEFAULT 0;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -5,6 +5,7 @@
 --   001_initial_schema.sql
 --   002_add_form_assessment_unique_constraint.sql
 --   003_enrollment_self_insert.sql
+--   004_quick_log_defaults.sql
 --
 -- Use this in the Supabase SQL Editor to set up a fresh database.
 -- For incremental updates, run the individual files in supabase/migrations/.
@@ -134,8 +135,8 @@ CREATE TABLE session_logs (
   user_id               uuid REFERENCES profiles(id) ON DELETE CASCADE,
   workout_template_id   uuid REFERENCES workout_templates(id),
   enrollment_id         uuid REFERENCES user_enrollments(id),
-  week_number           int NOT NULL,
-  session_number        int NOT NULL,
+  week_number           int NOT NULL DEFAULT 0,
+  session_number        int NOT NULL DEFAULT 0,
   started_at            timestamptz NULL,
   completed_at          timestamptz NULL,
   is_complete           boolean DEFAULT false,


### PR DESCRIPTION
## Summary
- Add migration `004_quick_log_defaults.sql` setting `DEFAULT 0` on `session_logs.week_number` and `session_logs.session_number` to fix NOT NULL constraint violations from the quick-log API
- Update `supabase/schema.sql` to reflect the new defaults, keeping the schema file in sync with migrations
- Mark roadmap item 9-1 as `in-progress` in `lib/roadmap-data.ts`

Closes #97

## Test plan
- [ ] Run migration against Supabase: verify `ALTER TABLE` succeeds
- [ ] POST to `/api/quick-log` without `week_number`/`session_number` — confirm row is inserted with defaults (0, 0)
- [ ] Verify existing session tracker flow (which provides explicit values) still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)