### PR TITLE
feat(10-3): Add RLS INSERT policy for coach_form_assessments

### DIFF
--- a/lib/roadmap-data.ts
+++ b/lib/roadmap-data.ts
@@ -577,7 +577,7 @@ export const ROADMAP: RoadmapBatch[] = [
           "Missing explicit INSERT WITH CHECK policy on coach_form_assessments.",
           "Add migration: CREATE POLICY form_assessments_coach_insert ON coach_form_assessments FOR INSERT WITH CHECK (coach_id = auth.uid());",
         ].join("\n"),
-        status: "not-started",
+        status: "in-progress",
         tests: false,
         branch: "fix/form-assessment-rls",
         issue: 120,

--- a/supabase/migrations/005_form_assessment_rls.sql
+++ b/supabase/migrations/005_form_assessment_rls.sql
@@ -1,0 +1,9 @@
+-- Add explicit INSERT policy for coach_form_assessments.
+-- The existing FOR ALL policy (form_assessments_coach_own) covers this implicitly,
+-- but an explicit INSERT WITH CHECK makes the intent unambiguous and guards against
+-- future policy changes that might narrow the FOR ALL scope.
+
+CREATE POLICY form_assessments_coach_insert
+  ON coach_form_assessments
+  FOR INSERT
+  WITH CHECK (coach_id = auth.uid());

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -413,6 +413,8 @@ CREATE POLICY "milestones_admin_all" ON milestones FOR ALL
 CREATE POLICY "form_assessments_coach_own" ON coach_form_assessments FOR ALL
   USING    (coach_id = auth.uid())
   WITH CHECK (coach_id = auth.uid());
+CREATE POLICY "form_assessments_coach_insert" ON coach_form_assessments FOR INSERT
+  WITH CHECK (coach_id = auth.uid());
 CREATE POLICY "form_assessments_admin_all" ON coach_form_assessments FOR ALL
   USING (auth_role() = 'admin');
 


### PR DESCRIPTION
## Summary
- Adds an explicit `INSERT WITH CHECK (coach_id = auth.uid())` RLS policy on `coach_form_assessments` via migration `005_form_assessment_rls.sql`
- Syncs the new policy into `supabase/schema.sql` alongside existing policies for that table
- Sets roadmap item `10-3` to `in-progress`

Closes #120

## Test plan
- [ ] Run migration `005_form_assessment_rls.sql` against Supabase SQL Editor
- [ ] Verify coach can insert form assessments for their clients
- [ ] Verify non-coach users cannot insert into `coach_form_assessments`
- [ ] Confirm no regression on existing `form_assessments_coach_own` FOR ALL policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)