### PR TITLE
feat(10-2): Verify update row counts — silent no-ops on sessions

### DIFF
--- a/app/api/sessions/[sessionLogId]/complete/route.ts
+++ b/app/api/sessions/[sessionLogId]/complete/route.ts
@@ -12,12 +12,20 @@ export async function POST(
 
   const { sessionLogId } = await params;
 
-  const { error } = await supabase
+  const { data, error } = await supabase
     .from("session_logs")
     .update({ is_complete: true, completed_at: new Date().toISOString() })
     .eq("id", sessionLogId)
-    .eq("user_id", user.id);
+    .eq("user_id", user.id)
+    .select("id")
+    .single();
 
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  if (error) {
+    if (error.code === "PGRST116") {
+      return NextResponse.json({ error: "Session not found" }, { status: 404 });
+    }
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  if (!data) return NextResponse.json({ error: "Session not found" }, { status: 404 });
   return NextResponse.json({ ok: true });
 }

--- a/app/api/sessions/[sessionLogId]/effort/route.ts
+++ b/app/api/sessions/[sessionLogId]/effort/route.ts
@@ -18,12 +18,20 @@ export async function POST(
     return NextResponse.json({ error: "Score must be 1–5" }, { status: 400 });
   }
 
-  const { error } = await supabase
+  const { data, error } = await supabase
     .from("session_logs")
     .update({ post_session_effort: score })
     .eq("id", sessionLogId)
-    .eq("user_id", user.id);
+    .eq("user_id", user.id)
+    .select("id")
+    .single();
 
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  if (error) {
+    if (error.code === "PGRST116") {
+      return NextResponse.json({ error: "Session not found" }, { status: 404 });
+    }
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  if (!data) return NextResponse.json({ error: "Session not found" }, { status: 404 });
   return NextResponse.json({ ok: true });
 }

--- a/app/api/sessions/[sessionLogId]/soreness/route.ts
+++ b/app/api/sessions/[sessionLogId]/soreness/route.ts
@@ -18,12 +18,20 @@ export async function POST(
     return NextResponse.json({ error: "Score must be 1–5" }, { status: 400 });
   }
 
-  const { error } = await supabase
+  const { data, error } = await supabase
     .from("session_logs")
     .update({ pre_session_soreness: score, soreness_prompted: true })
     .eq("id", sessionLogId)
-    .eq("user_id", user.id);
+    .eq("user_id", user.id)
+    .select("id")
+    .single();
 
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  if (error) {
+    if (error.code === "PGRST116") {
+      return NextResponse.json({ error: "Session not found" }, { status: 404 });
+    }
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  if (!data) return NextResponse.json({ error: "Session not found" }, { status: 404 });
   return NextResponse.json({ ok: true });
 }

--- a/lib/roadmap-data.ts
+++ b/lib/roadmap-data.ts
@@ -561,7 +561,7 @@ export const ROADMAP: RoadmapBatch[] = [
           "Fix: use .select('id').single() after .update() and check returned data.",
           "Return 404 if no rows affected.",
         ].join("\n"),
-        status: "not-started",
+        status: "in-progress",
         tests: true,
         branch: "fix/verify-update-row-counts",
         issue: 101,


### PR DESCRIPTION
## Summary
- Chains `.select('id').single()` after `.update()` on session mutation endpoints (`soreness`, `effort`, `complete`) so that a missing or RLS-blocked row returns a **404** instead of silently succeeding with `{ ok: true }`.
- Handles the Supabase `PGRST116` error code (zero rows from `.single()`) as a 404 distinct from other 500-level Supabase errors.
- Updates roadmap item `10-2` status to `in-progress` in `lib/roadmap-data.ts`.

Closes #101

## Test plan
- [ ] Call `POST /api/sessions/{valid-id}/soreness` with valid score — should succeed as before
- [ ] Call `POST /api/sessions/{nonexistent-id}/soreness` — should return 404 `{ error: "Session not found" }`
- [ ] Same verification for `/effort` and `/complete` endpoints
- [ ] Verify that RLS-blocked rows (another user's session) also return 404, not 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)