### PR TITLE
feat(10-1): Stop leaking database error messages to clients

### DIFF
--- a/app/api/quick-log/route.ts
+++ b/app/api/quick-log/route.ts
@@ -77,8 +77,9 @@ export async function POST(req: NextRequest) {
       .single();
 
     if (sessionError || !sessionLog) {
+      console.error("[quick-log/POST]", sessionError);
       return NextResponse.json(
-        { error: sessionError?.message ?? "Failed to save session" },
+        { error: "Failed to save session" },
         { status: 500 }
       );
     }

--- a/app/api/sessions/[sessionLogId]/complete/route.ts
+++ b/app/api/sessions/[sessionLogId]/complete/route.ts
@@ -24,7 +24,8 @@ export async function POST(
     if (error.code === "PGRST116") {
       return NextResponse.json({ error: "Session not found" }, { status: 404 });
     }
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    console.error("[sessions/complete/POST]", error);
+    return NextResponse.json({ error: "Failed to complete session" }, { status: 500 });
   }
   if (!data) return NextResponse.json({ error: "Session not found" }, { status: 404 });
   return NextResponse.json({ ok: true });

--- a/app/api/sessions/[sessionLogId]/effort/route.ts
+++ b/app/api/sessions/[sessionLogId]/effort/route.ts
@@ -30,7 +30,8 @@ export async function POST(
     if (error.code === "PGRST116") {
       return NextResponse.json({ error: "Session not found" }, { status: 404 });
     }
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    console.error("[sessions/effort/POST]", error);
+    return NextResponse.json({ error: "Failed to save effort score" }, { status: 500 });
   }
   if (!data) return NextResponse.json({ error: "Session not found" }, { status: 404 });
   return NextResponse.json({ ok: true });

--- a/app/api/sessions/[sessionLogId]/sets/route.ts
+++ b/app/api/sessions/[sessionLogId]/sets/route.ts
@@ -45,6 +45,9 @@ export async function POST(
     .select()
     .single();
 
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  if (error) {
+    console.error("[sessions/sets/POST]", error);
+    return NextResponse.json({ error: "Failed to log set" }, { status: 500 });
+  }
   return NextResponse.json(data, { status: 201 });
 }

--- a/app/api/sessions/[sessionLogId]/soreness/route.ts
+++ b/app/api/sessions/[sessionLogId]/soreness/route.ts
@@ -30,7 +30,8 @@ export async function POST(
     if (error.code === "PGRST116") {
       return NextResponse.json({ error: "Session not found" }, { status: 404 });
     }
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    console.error("[sessions/soreness/POST]", error);
+    return NextResponse.json({ error: "Failed to save soreness score" }, { status: 500 });
   }
   if (!data) return NextResponse.json({ error: "Session not found" }, { status: 404 });
   return NextResponse.json({ ok: true });

--- a/app/api/sessions/[sessionLogId]/start/route.ts
+++ b/app/api/sessions/[sessionLogId]/start/route.ts
@@ -20,7 +20,10 @@ export async function POST(
     .select()
     .single();
 
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  if (error) {
+    console.error("[sessions/start/POST]", error);
+    return NextResponse.json({ error: "Failed to start session" }, { status: 500 });
+  }
   if (!data) return NextResponse.json({ error: "Session not found" }, { status: 404 });
   return NextResponse.json(data);
 }

--- a/app/api/sessions/route.ts
+++ b/app/api/sessions/route.ts
@@ -29,6 +29,9 @@ export async function POST(request: Request) {
     .select()
     .single();
 
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  if (error) {
+    console.error("[sessions/POST]", error);
+    return NextResponse.json({ error: "Failed to create session" }, { status: 500 });
+  }
   return NextResponse.json(data, { status: 201 });
 }

--- a/lib/roadmap-data.ts
+++ b/lib/roadmap-data.ts
@@ -543,7 +543,7 @@ export const ROADMAP: RoadmapBatch[] = [
           "Replace all error.message responses with generic messages.",
           "Log the actual error server-side using console.error with context.",
         ].join("\n"),
-        status: "not-started",
+        status: "in-progress",
         tests: true,
         branch: "fix/sanitize-error-responses",
         issue: 100,


### PR DESCRIPTION
## Summary
- Replaced raw `error.message` from Supabase responses with generic client-facing messages across 7 API route handlers in `app/api/sessions/` and `app/api/quick-log/`
- Added `console.error` with route-name context before each generic response to preserve server-side debugging
- `app/api/progress/` routes already used generic messages and were left unchanged

## Routes fixed
- `app/api/sessions/route.ts` (POST)
- `app/api/sessions/[sessionLogId]/complete/route.ts` (POST)
- `app/api/sessions/[sessionLogId]/sets/route.ts` (POST)
- `app/api/sessions/[sessionLogId]/soreness/route.ts` (POST)
- `app/api/sessions/[sessionLogId]/start/route.ts` (POST)
- `app/api/sessions/[sessionLogId]/effort/route.ts` (POST)
- `app/api/quick-log/route.ts` (POST)

## Test plan
- [x] `pnpm tsc --noEmit` passes clean
- [x] `pnpm test` — all 836 tests pass
- [ ] Verify error responses in browser network tab no longer expose table/column names

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)