### PR TITLE
feat(10-4): Validate input on admin exercise/user creation routes

### DIFF
--- a/app/api/admin/exercises/route.ts
+++ b/app/api/admin/exercises/route.ts
@@ -1,6 +1,7 @@
 import { createClient } from "@/lib/supabase/server";
 import { NextResponse } from "next/server";
 import type { Exercise } from "@/lib/types";
+import { createExerciseSchema, updateExerciseSchema, deleteExerciseSchema } from "@/lib/validations/admin";
 
 export async function GET(request: Request) {
   try {
@@ -80,19 +81,20 @@ export async function POST(request: Request) {
     }
 
     const body = await request.json();
-    const { 
-      name, 
-      muscle_group, 
-      equipment, 
-      instructions, 
-      coaching_cues, 
-      video_url,
-      is_active = true 
-    } = body;
-
-    if (!name?.trim()) {
-      return NextResponse.json({ error: "Exercise name is required" }, { status: 400 });
+    const parsed = createExerciseSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid input" }, { status: 400 });
     }
+
+    const {
+      name,
+      muscle_group,
+      equipment,
+      instructions,
+      coaching_cues,
+      video_url,
+      is_active = true
+    } = parsed.data;
 
     // Check if exercise with same name already exists
     const { data: existing } = await supabase
@@ -153,24 +155,21 @@ export async function PUT(request: Request) {
     }
 
     const body = await request.json();
-    const { 
-      id, 
-      name, 
-      muscle_group, 
-      equipment, 
-      instructions, 
-      coaching_cues, 
-      video_url, 
-      is_active 
-    } = body;
-
-    if (!id) {
-      return NextResponse.json({ error: "Exercise ID is required" }, { status: 400 });
+    const parsed = updateExerciseSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid input" }, { status: 400 });
     }
 
-    if (!name?.trim()) {
-      return NextResponse.json({ error: "Exercise name is required" }, { status: 400 });
-    }
+    const {
+      id,
+      name,
+      muscle_group,
+      equipment,
+      instructions,
+      coaching_cues,
+      video_url,
+      is_active
+    } = parsed.data;
 
     // Check if another exercise with same name already exists (excluding current one)
     const { data: existing } = await supabase
@@ -237,11 +236,12 @@ export async function DELETE(request: Request) {
     }
 
     const body = await request.json();
-    const { id } = body;
-
-    if (!id) {
-      return NextResponse.json({ error: "Exercise ID is required" }, { status: 400 });
+    const parsed = deleteExerciseSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid input" }, { status: 400 });
     }
+
+    const { id } = parsed.data;
 
     // Check if exercise is used in any template exercises
     const { data: usageCount, error: countError } = await supabase

--- a/app/api/admin/exercises/template-exercises/route.ts
+++ b/app/api/admin/exercises/template-exercises/route.ts
@@ -1,6 +1,7 @@
 import { createClient } from "@/lib/supabase/server";
 import { NextResponse } from "next/server";
 import type { TemplateExercise } from "@/lib/types";
+import { updateTemplateExerciseSchema } from "@/lib/validations/admin";
 
 export async function GET(request: Request) {
   try {
@@ -103,8 +104,13 @@ export async function PUT(request: Request) {
     }
 
     const body = await request.json();
-    const { 
-      id, 
+    const parsed = updateTemplateExerciseSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid input" }, { status: 400 });
+    }
+
+    const {
+      id,
       sets_default,
       reps_default,
       weight_pre_baseline_f,
@@ -118,11 +124,7 @@ export async function PUT(request: Request) {
       is_abs_finisher,
       coaching_cues,
       notes
-    } = body;
-
-    if (!id) {
-      return NextResponse.json({ error: "Template exercise ID is required" }, { status: 400 });
-    }
+    } = parsed.data;
 
     // Create program version snapshot before making changes
     // First, get the program ID for this template exercise

--- a/app/api/admin/overrides/route.ts
+++ b/app/api/admin/overrides/route.ts
@@ -1,5 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
 import { NextResponse } from "next/server";
+import { upsertOverrideSchema, deleteOverrideSchema } from "@/lib/validations/admin";
 
 // GET /api/admin/overrides?user_id=<uuid> - Get all overrides for a user
 export async function GET(request: Request) {
@@ -76,20 +77,19 @@ export async function POST(request: Request) {
     }
 
     const body = await request.json();
-    const { 
-      user_id, 
-      template_exercise_id, 
-      sets_override, 
-      reps_override, 
-      weight_override, 
-      notes 
-    } = body;
-
-    if (!user_id || !template_exercise_id) {
-      return NextResponse.json({ 
-        error: "user_id and template_exercise_id are required" 
-      }, { status: 400 });
+    const parsed = upsertOverrideSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid input" }, { status: 400 });
     }
+
+    const {
+      user_id,
+      template_exercise_id,
+      sets_override,
+      reps_override,
+      weight_override,
+      notes
+    } = parsed.data;
 
     // Check if override already exists
     const { data: existingOverride } = await supabase
@@ -183,11 +183,12 @@ export async function DELETE(request: Request) {
     }
 
     const body = await request.json();
-    const { id } = body;
-
-    if (!id) {
-      return NextResponse.json({ error: "Override ID is required" }, { status: 400 });
+    const parsed = deleteOverrideSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid input" }, { status: 400 });
     }
+
+    const { id } = parsed.data;
 
     const { error } = await supabase
       .from("user_exercise_overrides")

--- a/app/api/admin/programs/[programId]/phases/route.ts
+++ b/app/api/admin/programs/[programId]/phases/route.ts
@@ -1,5 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
 import { NextResponse } from "next/server";
+import { updatePhaseSchema } from "@/lib/validations/admin";
 
 export async function PUT(
   request: Request,
@@ -26,11 +27,12 @@ export async function PUT(
     }
 
     const body = await request.json();
-    const { phaseId, name, subtitle, week_start, week_end, description } = body;
-
-    if (!phaseId) {
-      return NextResponse.json({ error: "Phase ID is required" }, { status: 400 });
+    const parsed = updatePhaseSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid input" }, { status: 400 });
     }
+
+    const { phaseId, name, subtitle, week_start, week_end, description } = parsed.data;
 
     // Update phase
     const updateData: any = {};

--- a/app/api/admin/programs/[programId]/session-editor/exercises/[exerciseId]/route.ts
+++ b/app/api/admin/programs/[programId]/session-editor/exercises/[exerciseId]/route.ts
@@ -1,6 +1,7 @@
 import { createClient } from '@/lib/supabase/server';
 import { requireRole } from '@/lib/rbac';
 import { NextRequest, NextResponse } from 'next/server';
+import { patchTemplateExerciseSchema } from '@/lib/validations/admin';
 
 export async function PATCH(
   request: NextRequest,
@@ -8,9 +9,15 @@ export async function PATCH(
 ) {
   try {
     await requireRole(['admin']);
-    
+
     const { exerciseId } = await params;
-    const updates = await request.json();
+    const body = await request.json();
+    const parsed = patchTemplateExerciseSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'Invalid input' }, { status: 400 });
+    }
+
+    const updates = parsed.data;
 
     const supabase = await createClient();
 

--- a/app/api/admin/programs/[programId]/session-editor/exercises/route.ts
+++ b/app/api/admin/programs/[programId]/session-editor/exercises/route.ts
@@ -1,6 +1,7 @@
 import { createClient } from '@/lib/supabase/server';
 import { requireRole } from '@/lib/rbac';
 import { NextRequest, NextResponse } from 'next/server';
+import { addSessionExerciseSchema } from '@/lib/validations/admin';
 
 export async function POST(
   request: NextRequest,
@@ -8,13 +9,15 @@ export async function POST(
 ) {
   try {
     await requireRole(['admin']);
-    
-    const { programId } = await params;
-    const { sessionId, exerciseId, orderIndex } = await request.json();
 
-    if (!sessionId || !exerciseId || typeof orderIndex !== 'number') {
-      return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
+    const { programId } = await params;
+    const body = await request.json();
+    const parsed = addSessionExerciseSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'Invalid input' }, { status: 400 });
     }
+
+    const { sessionId, exerciseId, orderIndex } = parsed.data;
 
     const supabase = await createClient();
 

--- a/app/api/admin/programs/[programId]/session-editor/reorder/route.ts
+++ b/app/api/admin/programs/[programId]/session-editor/reorder/route.ts
@@ -1,6 +1,7 @@
 import { createClient } from '@/lib/supabase/server';
 import { requireRole } from '@/lib/rbac';
 import { NextRequest, NextResponse } from 'next/server';
+import { reorderExercisesSchema } from '@/lib/validations/admin';
 
 export async function POST(
   request: NextRequest,
@@ -8,13 +9,15 @@ export async function POST(
 ) {
   try {
     await requireRole(['admin']);
-    
-    const { programId } = await params;
-    const { sessionId, exercises } = await request.json();
 
-    if (!sessionId || !Array.isArray(exercises)) {
-      return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
+    const { programId } = await params;
+    const body = await request.json();
+    const parsed = reorderExercisesSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'Invalid input' }, { status: 400 });
     }
+
+    const { sessionId, exercises } = parsed.data;
 
     const supabase = await createClient();
 

--- a/app/api/admin/programs/route.ts
+++ b/app/api/admin/programs/route.ts
@@ -1,5 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
 import { NextResponse } from "next/server";
+import { updateProgramSchema } from "@/lib/validations/admin";
 
 export async function GET() {
   try {
@@ -63,11 +64,12 @@ export async function PUT(request: Request) {
     }
 
     const body = await request.json();
-    const { id, name, description, total_phases, total_weeks } = body;
-
-    if (!id) {
-      return NextResponse.json({ error: "Program ID is required" }, { status: 400 });
+    const parsed = updateProgramSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid input" }, { status: 400 });
     }
+
+    const { id, name, description, total_phases, total_weeks } = parsed.data;
 
     // Update program
     const updateData: any = {};

--- a/app/api/admin/users/create/route.ts
+++ b/app/api/admin/users/create/route.ts
@@ -1,6 +1,7 @@
 import { createClient } from "@/lib/supabase/server";
 import { NextRequest, NextResponse } from "next/server";
 import { createClient as createServiceClient } from "@supabase/supabase-js";
+import { createUserSchema } from "@/lib/validations/admin";
 
 export async function POST(request: NextRequest) {
   try {
@@ -22,30 +23,12 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json();
-    const { email, password, full_name, gender, role, coach_id, template_tier } = body;
-
-    if (!email || !password) {
-      return NextResponse.json({ error: "Email and password are required" }, { status: 400 });
+    const parsed = createUserSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid input" }, { status: 400 });
     }
 
-    if (password.length < 6) {
-      return NextResponse.json({ error: "Password must be at least 6 characters" }, { status: 400 });
-    }
-
-    const validRoles = ["user", "coach", "admin"];
-    if (role && !validRoles.includes(role)) {
-      return NextResponse.json({ error: "Invalid role" }, { status: 400 });
-    }
-
-    const validGenders = ["male", "female", "other", "unset"];
-    if (gender && !validGenders.includes(gender)) {
-      return NextResponse.json({ error: "Invalid gender" }, { status: 400 });
-    }
-
-    const validTiers = ["pre_baseline", "default", "post_baseline"];
-    if (template_tier && !validTiers.includes(template_tier)) {
-      return NextResponse.json({ error: "Invalid template tier" }, { status: 400 });
-    }
+    const { email, password, full_name, gender, role, coach_id, template_tier } = parsed.data;
 
     const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
     if (!serviceRoleKey) {

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -1,5 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
 import { NextResponse } from "next/server";
+import { updateUserSchema, deleteUserSchema } from "@/lib/validations/admin";
 
 export async function GET() {
   try {
@@ -63,11 +64,12 @@ export async function PUT(request: Request) {
     }
 
     const body = await request.json();
-    const { id, role, coach_id, template_tier, full_name, gender } = body;
-
-    if (!id) {
-      return NextResponse.json({ error: "User ID is required" }, { status: 400 });
+    const parsed = updateUserSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid input" }, { status: 400 });
     }
+
+    const { id, role, coach_id, template_tier, full_name, gender } = parsed.data;
 
     // Update user profile
     const updateData: any = {};
@@ -117,11 +119,12 @@ export async function DELETE(request: Request) {
     }
 
     const body = await request.json();
-    const { id } = body;
-
-    if (!id) {
-      return NextResponse.json({ error: "User ID is required" }, { status: 400 });
+    const parsed = deleteUserSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid input" }, { status: 400 });
     }
+
+    const { id } = parsed.data;
 
     // Cannot delete yourself
     if (id === user.id) {

--- a/lib/roadmap-data.ts
+++ b/lib/roadmap-data.ts
@@ -593,7 +593,7 @@ export const ROADMAP: RoadmapBatch[] = [
           "No length limits on text fields, no range validation on numbers, no URL format validation.",
           "Add Zod validation to admin API routes for exercise/user creation.",
         ].join("\n"),
-        status: "not-started",
+        status: "in-progress",
         tests: true,
         branch: "fix/input-validation",
         issue: 103,

--- a/lib/validations/admin.ts
+++ b/lib/validations/admin.ts
@@ -1,0 +1,169 @@
+import { z } from "zod";
+
+// ─── Shared helpers ──────────────────────────────────────────────────────────
+
+const uuidSchema = z.string().uuid();
+const optionalUuid = z.string().uuid().nullish();
+
+/** Text field with a sensible max length. */
+const shortText = (max = 200) => z.string().max(max);
+const longText = (max = 2000) => z.string().max(max);
+
+/** Non-negative weight value (lbs/kg). */
+const weight = z.number().min(0).max(9999);
+
+// ─── User creation (POST /api/admin/users/create) ───────────────────────────
+
+export const createUserSchema = z.object({
+  email: z.string().email().max(320),
+  password: z.string().min(6).max(128),
+  full_name: shortText(200).nullish(),
+  gender: z.enum(["male", "female", "other", "unset"]).optional(),
+  role: z.enum(["user", "coach", "admin"]).optional(),
+  coach_id: optionalUuid,
+  template_tier: z.enum(["pre_baseline", "default", "post_baseline"]).optional(),
+});
+
+// ─── User update (PUT /api/admin/users) ─────────────────────────────────────
+
+export const updateUserSchema = z.object({
+  id: uuidSchema,
+  role: z.enum(["user", "coach", "admin"]).optional(),
+  coach_id: z.string().uuid().nullable().optional(),
+  template_tier: z.enum(["pre_baseline", "default", "post_baseline"]).optional(),
+  full_name: shortText(200).optional(),
+  gender: z.enum(["male", "female", "other", "unset"]).optional(),
+});
+
+// ─── User delete (DELETE /api/admin/users) ──────────────────────────────────
+
+export const deleteUserSchema = z.object({
+  id: uuidSchema,
+});
+
+// ─── Exercise creation (POST /api/admin/exercises) ──────────────────────────
+
+export const createExerciseSchema = z.object({
+  name: shortText(200).min(1),
+  muscle_group: shortText(100).nullish(),
+  equipment: shortText(100).nullish(),
+  instructions: longText(2000).nullish(),
+  coaching_cues: longText(2000).nullish(),
+  video_url: z.string().url().max(2000).nullish(),
+  is_active: z.boolean().optional(),
+});
+
+// ─── Exercise update (PUT /api/admin/exercises) ─────────────────────────────
+
+export const updateExerciseSchema = z.object({
+  id: uuidSchema,
+  name: shortText(200).min(1),
+  muscle_group: shortText(100).nullish(),
+  equipment: shortText(100).nullish(),
+  instructions: longText(2000).nullish(),
+  coaching_cues: longText(2000).nullish(),
+  video_url: z.string().url().max(2000).nullish(),
+  is_active: z.boolean().optional(),
+});
+
+// ─── Exercise delete (DELETE /api/admin/exercises) ──────────────────────────
+
+export const deleteExerciseSchema = z.object({
+  id: uuidSchema,
+});
+
+// ─── Template exercise update (PUT /api/admin/exercises/template-exercises) ─
+
+export const updateTemplateExerciseSchema = z.object({
+  id: uuidSchema,
+  sets_default: z.number().int().min(1).max(99).optional(),
+  reps_default: z.number().int().min(1).max(999).optional(),
+  weight_pre_baseline_f: weight.optional(),
+  weight_pre_baseline_m: weight.optional(),
+  weight_default_f: weight.optional(),
+  weight_default_m: weight.optional(),
+  weight_post_baseline_f: weight.optional(),
+  weight_post_baseline_m: weight.optional(),
+  superset_group: shortText(50).nullish(),
+  is_bodyweight: z.boolean().optional(),
+  is_abs_finisher: z.boolean().optional(),
+  coaching_cues: longText(2000).nullish(),
+  notes: longText(2000).nullish(),
+});
+
+// ─── Program update (PUT /api/admin/programs) ───────────────────────────────
+
+export const updateProgramSchema = z.object({
+  id: uuidSchema,
+  name: shortText(200).optional(),
+  description: longText(2000).nullish(),
+  total_phases: z.number().int().min(1).max(52).optional(),
+  total_weeks: z.number().int().min(1).max(52).optional(),
+});
+
+// ─── Phase update (PUT /api/admin/programs/[programId]/phases) ──────────────
+
+export const updatePhaseSchema = z.object({
+  phaseId: uuidSchema,
+  name: shortText(200).optional(),
+  subtitle: shortText(200).nullish(),
+  week_start: z.number().int().min(1).max(52).optional(),
+  week_end: z.number().int().min(1).max(52).optional(),
+  description: longText(2000).nullish(),
+});
+
+// ─── Session editor: add exercise (POST) ────────────────────────────────────
+
+export const addSessionExerciseSchema = z.object({
+  sessionId: uuidSchema,
+  exerciseId: uuidSchema,
+  orderIndex: z.number().int().min(0).max(999),
+});
+
+// ─── Session editor: update exercise (PATCH) ────────────────────────────────
+
+export const patchTemplateExerciseSchema = z.object({
+  sets_default: z.number().int().min(1).max(99).optional(),
+  reps_default: z.number().int().min(1).max(999).optional(),
+  weight_pre_baseline_f: weight.optional(),
+  weight_pre_baseline_m: weight.optional(),
+  weight_default_f: weight.optional(),
+  weight_default_m: weight.optional(),
+  weight_post_baseline_f: weight.optional(),
+  weight_post_baseline_m: weight.optional(),
+  superset_group: shortText(50).nullish(),
+  is_bodyweight: z.boolean().optional(),
+  is_abs_finisher: z.boolean().optional(),
+  coaching_cues: longText(2000).nullish(),
+  notes: longText(2000).nullish(),
+  order_index: z.number().int().min(0).max(999).optional(),
+});
+
+// ─── Session editor: reorder exercises (POST) ───────────────────────────────
+
+export const reorderExercisesSchema = z.object({
+  sessionId: uuidSchema,
+  exercises: z.array(
+    z.object({
+      id: uuidSchema,
+      order_index: z.number().int().min(0).max(999),
+    })
+  ).min(1).max(200),
+});
+
+// ─── Overrides: create/update (POST /api/admin/overrides) ───────────────────
+
+export const upsertOverrideSchema = z.object({
+  user_id: uuidSchema,
+  template_exercise_id: uuidSchema,
+  sets_override: z.number().int().min(1).max(99).nullish(),
+  reps_override: z.number().int().min(1).max(999).nullish(),
+  weight_override: weight.nullish(),
+  notes: longText(2000).nullish(),
+});
+
+// ─── Overrides: delete (DELETE /api/admin/overrides) ────────────────────────
+
+export const deleteOverrideSchema = z.object({
+  id: uuidSchema,
+});

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "tailwind-merge": "3.5.0",
     "tw-animate-css": "^1.4.0",
     "uuid": "13.0.0",
+    "zod": "catalog:",
     "zustand": "^5.0.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ catalogs:
     clsx:
       specifier: ^2.1.1
       version: 2.1.1
+    zod:
+      specifier: ^3.25.76
+      version: 3.25.76
 
 overrides:
   esbuild>@esbuild/darwin-arm64: '-'
@@ -184,6 +187,9 @@ importers:
       uuid:
         specifier: 13.0.0
         version: 13.0.0
+      zod:
+        specifier: 'catalog:'
+        version: 3.25.76
       zustand:
         specifier: ^5.0.3
         version: 5.0.3(@types/react@19.2.14)(immer@11.1.4)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
@@ -741,6 +747,7 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
@@ -3627,7 +3634,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@modelcontextprotocol/sdk@1.29.0':
+  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.14)
       ajv: 8.18.0
@@ -5389,7 +5396,7 @@ snapshots:
       '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
       '@dotenvx/dotenvx': 1.61.0
-      '@modelcontextprotocol/sdk': 1.29.0
+      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
       '@types/validate-npm-package-name': 4.0.2
       browserslist: 4.28.2
       commander: 14.0.3

--- a/tests/admin-exercises-api.test.ts
+++ b/tests/admin-exercises-api.test.ts
@@ -301,7 +301,7 @@ describe('/api/admin/exercises', () => {
       const data = await response.json();
 
       expect(response.status).toBe(400);
-      expect(data.error).toBe('Exercise name is required');
+      expect(data.error).toBe('Invalid input');
     });
   });
 
@@ -337,7 +337,7 @@ describe('/api/admin/exercises', () => {
         select: vi.fn().mockReturnThis(),
         single: vi.fn().mockResolvedValue({
           data: {
-            id: 'exercise-id',
+            id: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
             name: 'Updated Exercise',
             muscle_group: 'Updated Group',
             is_active: false
@@ -358,7 +358,7 @@ describe('/api/admin/exercises', () => {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          id: 'exercise-id',
+          id: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
           name: 'Updated Exercise',
           muscle_group: 'Updated Group',
           is_active: false
@@ -408,7 +408,7 @@ describe('/api/admin/exercises', () => {
       const data = await response.json();
 
       expect(response.status).toBe(400);
-      expect(data.error).toBe('Exercise ID is required');
+      expect(data.error).toBe('Invalid input');
     });
   });
 
@@ -455,7 +455,7 @@ describe('/api/admin/exercises', () => {
         method: 'DELETE',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          id: 'exercise-id'
+          id: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'
         })
       });
 
@@ -510,7 +510,7 @@ describe('/api/admin/exercises', () => {
         method: 'DELETE',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          id: 'exercise-id'
+          id: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'
         })
       });
 
@@ -548,7 +548,7 @@ describe('/api/admin/exercises', () => {
       const data = await response.json();
 
       expect(response.status).toBe(400);
-      expect(data.error).toBe('Exercise ID is required');
+      expect(data.error).toBe('Invalid input');
     });
   });
 });

--- a/tests/admin-users-api.test.ts
+++ b/tests/admin-users-api.test.ts
@@ -63,19 +63,19 @@ describe("Admin Users API", () => {
       mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: "admin-1" } } });
       mockSupabase.single
         .mockResolvedValueOnce({ data: { role: "admin" }, error: null })
-        .mockResolvedValueOnce({ data: { id: "u1", role: "coach" }, error: null });
+        .mockResolvedValueOnce({ data: { id: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", role: "coach" }, error: null });
 
       const request = new Request("http://localhost", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ id: "u1", role: "coach" }),
+        body: JSON.stringify({ id: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", role: "coach" }),
       });
 
       const response = await PUT(request);
       const data = await response.json();
 
       expect(response.status).toBe(200);
-      expect(data.id).toBe("u1");
+      expect(data.id).toBe("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11");
     });
 
     it("should return 400 for missing user ID", async () => {
@@ -106,7 +106,7 @@ describe("Admin Users API", () => {
       const request = new Request("http://localhost", {
         method: "DELETE",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ id: "u1" }),
+        body: JSON.stringify({ id: "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a22" }),
       });
 
       const response = await DELETE(request);
@@ -117,13 +117,14 @@ describe("Admin Users API", () => {
     });
 
     it("should prevent self-deletion", async () => {
-      mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: "admin-1" } } });
+      const selfId = "c0eebc99-9c0b-4ef8-bb6d-6bb9bd380a33";
+      mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: selfId } } });
       mockSupabase.single.mockResolvedValueOnce({ data: { role: "admin" }, error: null });
 
       const request = new Request("http://localhost", {
         method: "DELETE",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ id: "admin-1" }),
+        body: JSON.stringify({ id: selfId }),
       });
 
       const response = await DELETE(request);
@@ -145,7 +146,7 @@ describe("Admin Users API", () => {
       const response = await DELETE(request);
       expect(response.status).toBe(400);
       const data = await response.json();
-      expect(data.error).toBe("User ID is required");
+      expect(data.error).toBe("Invalid input");
     });
   });
 });

--- a/tests/admin/overrides.test.ts
+++ b/tests/admin/overrides.test.ts
@@ -79,7 +79,7 @@ describe("Overrides API Routes", () => {
 
       const mockOverrides = [
         {
-          id: "override-1",
+          id: "e0eebc99-9c0b-4ef8-bb6d-6bb9bd380a55",
           user_id: "user-1",
           template_exercise_id: "exercise-1",
           sets_override: 4,
@@ -130,13 +130,13 @@ describe("Overrides API Routes", () => {
 
       const request = new Request("http://localhost/api/admin/overrides", {
         method: "POST",
-        body: JSON.stringify({ user_id: "user-1" }),
+        body: JSON.stringify({ user_id: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11" }),
       });
       const response = await POST(request);
       const data = await response.json();
 
       expect(response.status).toBe(400);
-      expect(data.error).toBe("user_id and template_exercise_id are required");
+      expect(data.error).toBe("Invalid input");
     });
 
     it("should create new override successfully", async () => {
@@ -144,10 +144,12 @@ describe("Overrides API Routes", () => {
         data: { user: { id: "admin-1" } },
       });
 
+      const userId = "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11";
+      const templateExerciseId = "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a22";
       const newOverride = {
-        id: "override-1",
-        user_id: "user-1",
-        template_exercise_id: "exercise-1",
+        id: "c0eebc99-9c0b-4ef8-bb6d-6bb9bd380a33",
+        user_id: userId,
+        template_exercise_id: templateExerciseId,
         sets_override: 4,
       };
 
@@ -159,8 +161,8 @@ describe("Overrides API Routes", () => {
       const request = new Request("http://localhost/api/admin/overrides", {
         method: "POST",
         body: JSON.stringify({
-          user_id: "user-1",
-          template_exercise_id: "exercise-1",
+          user_id: userId,
+          template_exercise_id: templateExerciseId,
           sets_override: 4,
         }),
       });
@@ -176,23 +178,26 @@ describe("Overrides API Routes", () => {
         data: { user: { id: "admin-1" } },
       });
 
+      const userId = "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11";
+      const templateExerciseId = "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a22";
+      const existingOverrideId = "d0eebc99-9c0b-4ef8-bb6d-6bb9bd380a44";
       const updatedOverride = {
-        id: "existing-override-1",
-        user_id: "user-1",
-        template_exercise_id: "exercise-1",
+        id: existingOverrideId,
+        user_id: userId,
+        template_exercise_id: templateExerciseId,
         sets_override: 5,
       };
 
       mockSupabase.single
         .mockResolvedValueOnce({ data: { role: "admin" }, error: null })
-        .mockResolvedValueOnce({ data: { id: "existing-override-1" }, error: null })
+        .mockResolvedValueOnce({ data: { id: existingOverrideId }, error: null })
         .mockResolvedValueOnce({ data: updatedOverride, error: null });
 
       const request = new Request("http://localhost/api/admin/overrides", {
         method: "POST",
         body: JSON.stringify({
-          user_id: "user-1",
-          template_exercise_id: "exercise-1",
+          user_id: userId,
+          template_exercise_id: templateExerciseId,
           sets_override: 5,
         }),
       });
@@ -210,7 +215,7 @@ describe("Overrides API Routes", () => {
 
       const request = new Request("http://localhost/api/admin/overrides", {
         method: "DELETE",
-        body: JSON.stringify({ id: "override-1" }),
+        body: JSON.stringify({ id: "e0eebc99-9c0b-4ef8-bb6d-6bb9bd380a55" }),
       });
       const response = await DELETE(request);
 
@@ -234,7 +239,7 @@ describe("Overrides API Routes", () => {
       const data = await response.json();
 
       expect(response.status).toBe(400);
-      expect(data.error).toBe("Override ID is required");
+      expect(data.error).toBe("Invalid input");
     });
 
     it("should delete override successfully", async () => {
@@ -252,7 +257,7 @@ describe("Overrides API Routes", () => {
 
       const request = new Request("http://localhost/api/admin/overrides", {
         method: "DELETE",
-        body: JSON.stringify({ id: "override-1" }),
+        body: JSON.stringify({ id: "e0eebc99-9c0b-4ef8-bb6d-6bb9bd380a55" }),
       });
       const response = await DELETE(request);
       const data = await response.json();

--- a/tests/create-user-api.test.ts
+++ b/tests/create-user-api.test.ts
@@ -75,7 +75,7 @@ describe("POST /api/admin/users/create", () => {
     const response = await POST(makeRequest({ password: "123456" }));
     expect(response.status).toBe(400);
     const data = await response.json();
-    expect(data.error).toBe("Email and password are required");
+    expect(data.error).toBe("Invalid input");
   });
 
   it("should return 400 if password is too short", async () => {
@@ -85,7 +85,7 @@ describe("POST /api/admin/users/create", () => {
     const response = await POST(makeRequest({ email: "a@b.com", password: "123" }));
     expect(response.status).toBe(400);
     const data = await response.json();
-    expect(data.error).toBe("Password must be at least 6 characters");
+    expect(data.error).toBe("Invalid input");
   });
 
   it("should return 400 for invalid role", async () => {
@@ -95,7 +95,7 @@ describe("POST /api/admin/users/create", () => {
     const response = await POST(makeRequest({ email: "a@b.com", password: "123456", role: "superadmin" }));
     expect(response.status).toBe(400);
     const data = await response.json();
-    expect(data.error).toBe("Invalid role");
+    expect(data.error).toBe("Invalid input");
   });
 
   it("should return 400 for invalid gender", async () => {
@@ -105,7 +105,7 @@ describe("POST /api/admin/users/create", () => {
     const response = await POST(makeRequest({ email: "a@b.com", password: "123456", gender: "xyz" }));
     expect(response.status).toBe(400);
     const data = await response.json();
-    expect(data.error).toBe("Invalid gender");
+    expect(data.error).toBe("Invalid input");
   });
 
   it("should return 400 for invalid template tier", async () => {
@@ -115,7 +115,7 @@ describe("POST /api/admin/users/create", () => {
     const response = await POST(makeRequest({ email: "a@b.com", password: "123456", template_tier: "mega" }));
     expect(response.status).toBe(400);
     const data = await response.json();
-    expect(data.error).toBe("Invalid template tier");
+    expect(data.error).toBe("Invalid input");
   });
 
   it("should return 409 if email already exists", async () => {

--- a/tests/input-validation.test.ts
+++ b/tests/input-validation.test.ts
@@ -1,0 +1,560 @@
+import { describe, it, expect } from "vitest";
+import {
+  createUserSchema,
+  updateUserSchema,
+  deleteUserSchema,
+  createExerciseSchema,
+  updateExerciseSchema,
+  deleteExerciseSchema,
+  updateTemplateExerciseSchema,
+  updateProgramSchema,
+  updatePhaseSchema,
+  addSessionExerciseSchema,
+  patchTemplateExerciseSchema,
+  reorderExercisesSchema,
+  upsertOverrideSchema,
+  deleteOverrideSchema,
+} from "@/lib/validations/admin";
+
+const VALID_UUID = "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11";
+
+// ─── createUserSchema ────────────────────────────────────────────────────────
+
+describe("createUserSchema", () => {
+  const validInput = {
+    email: "user@example.com",
+    password: "securePass123",
+    full_name: "Test User",
+    gender: "male" as const,
+    role: "user" as const,
+    template_tier: "default" as const,
+  };
+
+  it("accepts valid input", () => {
+    const result = createUserSchema.safeParse(validInput);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts minimal input (email + password only)", () => {
+    const result = createUserSchema.safeParse({
+      email: "user@example.com",
+      password: "abc123",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects missing email", () => {
+    const result = createUserSchema.safeParse({ ...validInput, email: undefined });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing password", () => {
+    const result = createUserSchema.safeParse({ ...validInput, password: undefined });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid email format", () => {
+    const result = createUserSchema.safeParse({ ...validInput, email: "not-an-email" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects password shorter than 6 characters", () => {
+    const result = createUserSchema.safeParse({ ...validInput, password: "abc" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects password longer than 128 characters", () => {
+    const result = createUserSchema.safeParse({ ...validInput, password: "x".repeat(129) });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid role", () => {
+    const result = createUserSchema.safeParse({ ...validInput, role: "superadmin" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid gender", () => {
+    const result = createUserSchema.safeParse({ ...validInput, gender: "unknown" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid template_tier", () => {
+    const result = createUserSchema.safeParse({ ...validInput, template_tier: "ultra" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects full_name exceeding 200 characters", () => {
+    const result = createUserSchema.safeParse({ ...validInput, full_name: "x".repeat(201) });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-UUID coach_id", () => {
+    const result = createUserSchema.safeParse({ ...validInput, coach_id: "not-a-uuid" });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts valid UUID coach_id", () => {
+    const result = createUserSchema.safeParse({ ...validInput, coach_id: VALID_UUID });
+    expect(result.success).toBe(true);
+  });
+});
+
+// ─── updateUserSchema ────────────────────────────────────────────────────────
+
+describe("updateUserSchema", () => {
+  it("accepts valid input", () => {
+    const result = updateUserSchema.safeParse({
+      id: VALID_UUID,
+      role: "coach",
+      full_name: "Updated Name",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects missing id", () => {
+    const result = updateUserSchema.safeParse({ role: "user" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid UUID for id", () => {
+    const result = updateUserSchema.safeParse({ id: "bad-id" });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ─── deleteUserSchema ────────────────────────────────────────────────────────
+
+describe("deleteUserSchema", () => {
+  it("accepts valid UUID", () => {
+    const result = deleteUserSchema.safeParse({ id: VALID_UUID });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects missing id", () => {
+    const result = deleteUserSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-UUID id", () => {
+    const result = deleteUserSchema.safeParse({ id: "123" });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ─── createExerciseSchema ────────────────────────────────────────────────────
+
+describe("createExerciseSchema", () => {
+  const validInput = {
+    name: "Bench Press",
+    muscle_group: "Chest",
+    equipment: "Barbell",
+    instructions: "Lie flat on a bench and press the barbell upward.",
+    coaching_cues: "Keep your feet flat on the floor.",
+    video_url: "https://example.com/video.mp4",
+  };
+
+  it("accepts valid input", () => {
+    const result = createExerciseSchema.safeParse(validInput);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts minimal input (name only)", () => {
+    const result = createExerciseSchema.safeParse({ name: "Squat" });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects empty name", () => {
+    const result = createExerciseSchema.safeParse({ ...validInput, name: "" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing name", () => {
+    const { name, ...rest } = validInput;
+    const result = createExerciseSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects name exceeding 200 characters", () => {
+    const result = createExerciseSchema.safeParse({ ...validInput, name: "x".repeat(201) });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects instructions exceeding 2000 characters", () => {
+    const result = createExerciseSchema.safeParse({
+      ...validInput,
+      instructions: "x".repeat(2001),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid video_url format", () => {
+    const result = createExerciseSchema.safeParse({
+      ...validInput,
+      video_url: "not-a-url",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts null video_url", () => {
+    const result = createExerciseSchema.safeParse({ ...validInput, video_url: null });
+    expect(result.success).toBe(true);
+  });
+});
+
+// ─── updateExerciseSchema ────────────────────────────────────────────────────
+
+describe("updateExerciseSchema", () => {
+  it("requires both id and name", () => {
+    const result = updateExerciseSchema.safeParse({
+      id: VALID_UUID,
+      name: "Updated Exercise",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects missing id", () => {
+    const result = updateExerciseSchema.safeParse({ name: "Updated Exercise" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing name", () => {
+    const result = updateExerciseSchema.safeParse({ id: VALID_UUID });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ─── deleteExerciseSchema ────────────────────────────────────────────────────
+
+describe("deleteExerciseSchema", () => {
+  it("accepts valid UUID", () => {
+    const result = deleteExerciseSchema.safeParse({ id: VALID_UUID });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects missing id", () => {
+    const result = deleteExerciseSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+});
+
+// ─── updateTemplateExerciseSchema ────────────────────────────────────────────
+
+describe("updateTemplateExerciseSchema", () => {
+  it("accepts valid input with all weight fields", () => {
+    const result = updateTemplateExerciseSchema.safeParse({
+      id: VALID_UUID,
+      sets_default: 4,
+      reps_default: 10,
+      weight_default_f: 45,
+      weight_default_m: 95,
+      weight_pre_baseline_f: 25,
+      weight_pre_baseline_m: 65,
+      weight_post_baseline_f: 55,
+      weight_post_baseline_m: 115,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects sets_default of 0", () => {
+    const result = updateTemplateExerciseSchema.safeParse({
+      id: VALID_UUID,
+      sets_default: 0,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects sets_default over 99", () => {
+    const result = updateTemplateExerciseSchema.safeParse({
+      id: VALID_UUID,
+      sets_default: 100,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects reps_default of 0", () => {
+    const result = updateTemplateExerciseSchema.safeParse({
+      id: VALID_UUID,
+      reps_default: 0,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects reps_default over 999", () => {
+    const result = updateTemplateExerciseSchema.safeParse({
+      id: VALID_UUID,
+      reps_default: 1000,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects negative weight", () => {
+    const result = updateTemplateExerciseSchema.safeParse({
+      id: VALID_UUID,
+      weight_default_f: -5,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects weight over 9999", () => {
+    const result = updateTemplateExerciseSchema.safeParse({
+      id: VALID_UUID,
+      weight_default_m: 10000,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-integer sets_default", () => {
+    const result = updateTemplateExerciseSchema.safeParse({
+      id: VALID_UUID,
+      sets_default: 3.5,
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ─── updateProgramSchema ─────────────────────────────────────────────────────
+
+describe("updateProgramSchema", () => {
+  it("accepts valid input", () => {
+    const result = updateProgramSchema.safeParse({
+      id: VALID_UUID,
+      name: "12-Week Strength",
+      total_phases: 3,
+      total_weeks: 12,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects missing id", () => {
+    const result = updateProgramSchema.safeParse({ name: "Test" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects total_phases of 0", () => {
+    const result = updateProgramSchema.safeParse({
+      id: VALID_UUID,
+      total_phases: 0,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects total_weeks over 52", () => {
+    const result = updateProgramSchema.safeParse({
+      id: VALID_UUID,
+      total_weeks: 53,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects description over 2000 characters", () => {
+    const result = updateProgramSchema.safeParse({
+      id: VALID_UUID,
+      description: "x".repeat(2001),
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ─── updatePhaseSchema ───────────────────────────────────────────────────────
+
+describe("updatePhaseSchema", () => {
+  it("accepts valid input", () => {
+    const result = updatePhaseSchema.safeParse({
+      phaseId: VALID_UUID,
+      name: "Hypertrophy",
+      week_start: 1,
+      week_end: 4,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects missing phaseId", () => {
+    const result = updatePhaseSchema.safeParse({ name: "Test" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects week_start of 0", () => {
+    const result = updatePhaseSchema.safeParse({
+      phaseId: VALID_UUID,
+      week_start: 0,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects week_end over 52", () => {
+    const result = updatePhaseSchema.safeParse({
+      phaseId: VALID_UUID,
+      week_end: 53,
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ─── addSessionExerciseSchema ────────────────────────────────────────────────
+
+describe("addSessionExerciseSchema", () => {
+  it("accepts valid input", () => {
+    const result = addSessionExerciseSchema.safeParse({
+      sessionId: VALID_UUID,
+      exerciseId: VALID_UUID,
+      orderIndex: 0,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects missing sessionId", () => {
+    const result = addSessionExerciseSchema.safeParse({
+      exerciseId: VALID_UUID,
+      orderIndex: 0,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects negative orderIndex", () => {
+    const result = addSessionExerciseSchema.safeParse({
+      sessionId: VALID_UUID,
+      exerciseId: VALID_UUID,
+      orderIndex: -1,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects orderIndex over 999", () => {
+    const result = addSessionExerciseSchema.safeParse({
+      sessionId: VALID_UUID,
+      exerciseId: VALID_UUID,
+      orderIndex: 1000,
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ─── patchTemplateExerciseSchema ─────────────────────────────────────────────
+
+describe("patchTemplateExerciseSchema", () => {
+  it("accepts valid partial update", () => {
+    const result = patchTemplateExerciseSchema.safeParse({
+      sets_default: 5,
+      reps_default: 12,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts empty object (no fields to update)", () => {
+    const result = patchTemplateExerciseSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects out-of-range sets_default", () => {
+    const result = patchTemplateExerciseSchema.safeParse({ sets_default: 100 });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ─── reorderExercisesSchema ──────────────────────────────────────────────────
+
+describe("reorderExercisesSchema", () => {
+  it("accepts valid input", () => {
+    const result = reorderExercisesSchema.safeParse({
+      sessionId: VALID_UUID,
+      exercises: [
+        { id: VALID_UUID, order_index: 0 },
+        { id: VALID_UUID, order_index: 1 },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects empty exercises array", () => {
+    const result = reorderExercisesSchema.safeParse({
+      sessionId: VALID_UUID,
+      exercises: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing sessionId", () => {
+    const result = reorderExercisesSchema.safeParse({
+      exercises: [{ id: VALID_UUID, order_index: 0 }],
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ─── upsertOverrideSchema ───────────────────────────────────────────────────
+
+describe("upsertOverrideSchema", () => {
+  it("accepts valid input", () => {
+    const result = upsertOverrideSchema.safeParse({
+      user_id: VALID_UUID,
+      template_exercise_id: VALID_UUID,
+      sets_override: 5,
+      reps_override: 10,
+      weight_override: 135,
+      notes: "Light day — recovering from strain.",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects missing user_id", () => {
+    const result = upsertOverrideSchema.safeParse({
+      template_exercise_id: VALID_UUID,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing template_exercise_id", () => {
+    const result = upsertOverrideSchema.safeParse({
+      user_id: VALID_UUID,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects negative weight_override", () => {
+    const result = upsertOverrideSchema.safeParse({
+      user_id: VALID_UUID,
+      template_exercise_id: VALID_UUID,
+      weight_override: -10,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects sets_override of 0", () => {
+    const result = upsertOverrideSchema.safeParse({
+      user_id: VALID_UUID,
+      template_exercise_id: VALID_UUID,
+      sets_override: 0,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts null overrides", () => {
+    const result = upsertOverrideSchema.safeParse({
+      user_id: VALID_UUID,
+      template_exercise_id: VALID_UUID,
+      sets_override: null,
+      reps_override: null,
+      weight_override: null,
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+// ─── deleteOverrideSchema ───────────────────────────────────────────────────
+
+describe("deleteOverrideSchema", () => {
+  it("accepts valid UUID", () => {
+    const result = deleteOverrideSchema.safeParse({ id: VALID_UUID });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects missing id", () => {
+    const result = deleteOverrideSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-UUID string", () => {
+    const result = deleteOverrideSchema.safeParse({ id: "abc" });
+    expect(result.success).toBe(false);
+  });
+});

--- a/tests/program-editor.test.ts
+++ b/tests/program-editor.test.ts
@@ -121,7 +121,7 @@ describe("Program Editor API", () => {
 
     it("should update program when user is admin", async () => {
       const updateData = {
-        id: "prog-1",
+        id: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
         name: "Updated Program",
         description: "Updated description",
         total_phases: 4,
@@ -156,7 +156,7 @@ describe("Program Editor API", () => {
       const response = await programsPUT(request);
       const data = await response.json();
 
-      expect(data.error).toBe("Program ID is required");
+      expect(data.error).toBe("Invalid input");
       expect(response.status).toBe(400);
     });
   });
@@ -214,8 +214,9 @@ describe("Program Editor API", () => {
     const mockParams = { params: Promise.resolve({ programId: "prog-1" }) };
 
     it("should update phase successfully", async () => {
+      const phaseUuid = "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a22";
       const updateData = {
-        phaseId: "phase-1",
+        phaseId: phaseUuid,
         name: "Updated Phase",
         subtitle: "Updated subtitle",
         week_start: 1,
@@ -228,14 +229,14 @@ describe("Program Editor API", () => {
       });
       mockSupabase.single
         .mockResolvedValueOnce({ data: { role: "admin" }, error: null })
-        .mockResolvedValueOnce({ data: { id: "phase-1", ...updateData }, error: null });
+        .mockResolvedValueOnce({ data: { id: phaseUuid, ...updateData }, error: null });
 
       const request = mockRequest(updateData);
       const response = await phasePUT(request, mockParams);
       const data = await response.json();
 
       expect(response.status).toBe(200);
-      expect(data.id).toBe("phase-1");
+      expect(data.id).toBe(phaseUuid);
     });
 
     it("should return error when phase ID is missing", async () => {
@@ -251,7 +252,7 @@ describe("Program Editor API", () => {
       const response = await phasePUT(request, mockParams);
       const data = await response.json();
 
-      expect(data.error).toBe("Phase ID is required");
+      expect(data.error).toBe("Invalid input");
       expect(response.status).toBe(400);
     });
   });

--- a/tests/session-editor-api.test.ts
+++ b/tests/session-editor-api.test.ts
@@ -72,10 +72,10 @@ describe('Session Editor API Routes', () => {
       const request = new NextRequest('http://localhost:3000/api/admin/programs/program-1/session-editor/reorder', {
         method: 'POST',
         body: JSON.stringify({
-          sessionId: 'session-1',
+          sessionId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
           exercises: [
-            { id: 'exercise-1', order_index: 1 },
-            { id: 'exercise-2', order_index: 0 }
+            { id: 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a22', order_index: 1 },
+            { id: 'c0eebc99-9c0b-4ef8-bb6d-6bb9bd380a33', order_index: 0 }
           ]
         })
       });
@@ -92,7 +92,7 @@ describe('Session Editor API Routes', () => {
       const request = new NextRequest('http://localhost:3000/api/admin/programs/program-1/session-editor/reorder', {
         method: 'POST',
         body: JSON.stringify({
-          sessionId: 'session-1'
+          sessionId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'
           // missing exercises array
         })
       });
@@ -102,7 +102,7 @@ describe('Session Editor API Routes', () => {
       const data = await response.json();
 
       expect(response.status).toBe(400);
-      expect(data.error).toBe('Missing required fields');
+      expect(data.error).toBe('Invalid input');
     });
   });
 

--- a/tests/template-exercises-api.test.ts
+++ b/tests/template-exercises-api.test.ts
@@ -88,7 +88,7 @@ describe('/api/admin/exercises/template-exercises', () => {
         order: vi.fn().mockResolvedValue({
           data: [
             {
-              id: 'template-exercise-1',
+              id: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
               exercise_id: 'exercise-1',
               workout_template_id: 'workout-1',
               sets_default: 3,
@@ -246,7 +246,7 @@ describe('/api/admin/exercises/template-exercises', () => {
         select: vi.fn().mockReturnThis(),
         single: vi.fn().mockResolvedValue({
           data: {
-            id: 'template-exercise-1',
+            id: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
             sets_default: 4,
             reps_default: 8,
             weight_default_f: 105,
@@ -274,7 +274,7 @@ describe('/api/admin/exercises/template-exercises', () => {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          id: 'template-exercise-1',
+          id: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
           sets_default: 4,
           reps_default: 8,
           weight_default_f: 105,
@@ -338,7 +338,7 @@ describe('/api/admin/exercises/template-exercises', () => {
       const data = await response.json();
 
       expect(response.status).toBe(400);
-      expect(data.error).toBe('Template exercise ID is required');
+      expect(data.error).toBe('Invalid input');
     });
 
     it('should handle template exercise not found', async () => {
@@ -374,7 +374,7 @@ describe('/api/admin/exercises/template-exercises', () => {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          id: 'non-existent-id',
+          id: 'd0eebc99-9c0b-4ef8-bb6d-6bb9bd380a44',
           sets_default: 3
         })
       });
@@ -438,7 +438,7 @@ describe('/api/admin/exercises/template-exercises', () => {
         select: vi.fn().mockReturnThis(),
         single: vi.fn().mockResolvedValue({
           data: {
-            id: 'template-exercise-1',
+            id: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
             is_bodyweight: true,
             weight_default_f: 0,
             weight_default_m: 0,
@@ -465,7 +465,7 @@ describe('/api/admin/exercises/template-exercises', () => {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          id: 'template-exercise-1',
+          id: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
           is_bodyweight: true,
           weight_default_f: 0,
           weight_default_m: 0

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     setupFiles: ["./tests/setup.ts"],
+    exclude: ["**/node_modules/**", "**/.migration-backup/**"],
     coverage: {
       provider: "v8",
       include: ["lib/**/*.ts"],


### PR DESCRIPTION
## Summary
- Added Zod validation schemas to all admin API routes (`lib/validations/admin.ts`)
- Text fields: max length (200 for names, 2000 for descriptions)
- Number fields: range checks (weight 0-9999, sets 1-99, reps 1-999)
- Email: format validation; UUIDs: format validation; Enums: valid values only
- All validation failures return generic 400 "Invalid input" (no Zod details leaked)
- 68 new unit tests in `tests/input-validation.test.ts` covering every schema
- Updated existing tests to use valid UUIDs and match new error messages

## Routes validated
- `POST /api/admin/users/create` — user creation
- `PUT/DELETE /api/admin/users` — user update/delete
- `POST/PUT/DELETE /api/admin/exercises` — exercise CRUD
- `PUT /api/admin/exercises/template-exercises` — template exercise update
- `PUT /api/admin/programs` — program update
- `PUT /api/admin/programs/[id]/phases` — phase update
- `POST/PATCH /api/admin/programs/[id]/session-editor/exercises` — session exercise add/update
- `POST /api/admin/programs/[id]/session-editor/reorder` — exercise reorder
- `POST/DELETE /api/admin/overrides` — override upsert/delete

## Test plan
- [x] `pnpm test` — all 486 tests pass (34 files)
- [x] `pnpm tsc --noEmit` — clean
- [x] Valid input passes through to Supabase operations
- [x] Missing required fields return 400
- [x] Out-of-range numbers return 400
- [x] Invalid email/UUID/enum values return 400
- [x] Existing tests updated to match new validation behavior

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)