### PR TITLE
feat(11-3): Add error boundaries to React app

### DIFF
--- a/app/(admin)/error.tsx
+++ b/app/(admin)/error.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function AdminError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("Admin section error boundary caught:", error);
+  }, [error]);
+
+  return (
+    <div
+      style={{
+        minHeight: "60vh",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: "24px",
+        fontFamily: "var(--font-inter, Inter, sans-serif)",
+      }}
+    >
+      <div
+        style={{
+          maxWidth: "480px",
+          width: "100%",
+          textAlign: "center",
+          background: "#E8DECE",
+          border: "1px solid #C8B99D",
+          borderRadius: "12px",
+          padding: "48px 32px",
+        }}
+      >
+        <div
+          style={{
+            fontSize: "48px",
+            marginBottom: "16px",
+          }}
+          aria-hidden="true"
+        >
+          &#9888;
+        </div>
+        <h1
+          style={{
+            fontSize: "24px",
+            fontWeight: 700,
+            color: "#2C1A10",
+            marginBottom: "8px",
+            fontFamily: "var(--font-space-grotesk, Space Grotesk, sans-serif)",
+          }}
+        >
+          Admin panel error
+        </h1>
+        <p
+          style={{
+            fontSize: "16px",
+            color: "#6B5A48",
+            marginBottom: "32px",
+            lineHeight: 1.5,
+          }}
+        >
+          Something went wrong in the admin section. No changes were saved. Try
+          again or refresh the page.
+        </p>
+        <button
+          onClick={reset}
+          style={{
+            background: "#C84B1A",
+            color: "#FEFCF8",
+            border: "none",
+            borderRadius: "8px",
+            padding: "12px 32px",
+            fontSize: "16px",
+            fontWeight: 600,
+            cursor: "pointer",
+            fontFamily: "var(--font-inter, Inter, sans-serif)",
+          }}
+        >
+          Try again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/error.tsx
+++ b/app/(app)/error.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function AppError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("App section error boundary caught:", error);
+  }, [error]);
+
+  return (
+    <div
+      style={{
+        minHeight: "60vh",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: "24px",
+        fontFamily: "var(--font-inter, Inter, sans-serif)",
+      }}
+    >
+      <div
+        style={{
+          maxWidth: "480px",
+          width: "100%",
+          textAlign: "center",
+          background: "#E8DECE",
+          border: "1px solid #C8B99D",
+          borderRadius: "12px",
+          padding: "48px 32px",
+        }}
+      >
+        <div
+          style={{
+            fontSize: "48px",
+            marginBottom: "16px",
+          }}
+          aria-hidden="true"
+        >
+          &#9888;
+        </div>
+        <h1
+          style={{
+            fontSize: "24px",
+            fontWeight: 700,
+            color: "#2C1A10",
+            marginBottom: "8px",
+            fontFamily: "var(--font-space-grotesk, Space Grotesk, sans-serif)",
+          }}
+        >
+          Something went wrong
+        </h1>
+        <p
+          style={{
+            fontSize: "16px",
+            color: "#6B5A48",
+            marginBottom: "32px",
+            lineHeight: 1.5,
+          }}
+        >
+          We hit an error loading this page. Your data is safe — try again or
+          head back to the dashboard.
+        </p>
+        <button
+          onClick={reset}
+          style={{
+            background: "#C84B1A",
+            color: "#FEFCF8",
+            border: "none",
+            borderRadius: "8px",
+            padding: "12px 32px",
+            fontSize: "16px",
+            fontWeight: 600,
+            cursor: "pointer",
+            fontFamily: "var(--font-inter, Inter, sans-serif)",
+          }}
+        >
+          Try again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/(coach)/error.tsx
+++ b/app/(coach)/error.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function CoachError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("Coach section error boundary caught:", error);
+  }, [error]);
+
+  return (
+    <div
+      style={{
+        minHeight: "60vh",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: "24px",
+        fontFamily: "var(--font-inter, Inter, sans-serif)",
+      }}
+    >
+      <div
+        style={{
+          maxWidth: "480px",
+          width: "100%",
+          textAlign: "center",
+          background: "#E8DECE",
+          border: "1px solid #C8B99D",
+          borderRadius: "12px",
+          padding: "48px 32px",
+        }}
+      >
+        <div
+          style={{
+            fontSize: "48px",
+            marginBottom: "16px",
+          }}
+          aria-hidden="true"
+        >
+          &#9888;
+        </div>
+        <h1
+          style={{
+            fontSize: "24px",
+            fontWeight: 700,
+            color: "#2C1A10",
+            marginBottom: "8px",
+            fontFamily: "var(--font-space-grotesk, Space Grotesk, sans-serif)",
+          }}
+        >
+          Something went wrong
+        </h1>
+        <p
+          style={{
+            fontSize: "16px",
+            color: "#6B5A48",
+            marginBottom: "32px",
+            lineHeight: 1.5,
+          }}
+        >
+          We hit an error loading the coaching panel. Client data is unaffected.
+          Try again or refresh the page.
+        </p>
+        <button
+          onClick={reset}
+          style={{
+            background: "#C84B1A",
+            color: "#FEFCF8",
+            border: "none",
+            borderRadius: "8px",
+            padding: "12px 32px",
+            fontSize: "16px",
+            fontWeight: 600,
+            cursor: "pointer",
+            fontFamily: "var(--font-inter, Inter, sans-serif)",
+          }}
+        >
+          Try again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function RootError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("Root error boundary caught:", error);
+  }, [error]);
+
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "#EDE4D3",
+        padding: "24px",
+        fontFamily: "var(--font-inter, Inter, sans-serif)",
+      }}
+    >
+      <div
+        style={{
+          maxWidth: "480px",
+          width: "100%",
+          textAlign: "center",
+          background: "#E8DECE",
+          border: "1px solid #C8B99D",
+          borderRadius: "12px",
+          padding: "48px 32px",
+        }}
+      >
+        <div
+          style={{
+            fontSize: "48px",
+            marginBottom: "16px",
+          }}
+          aria-hidden="true"
+        >
+          &#9888;
+        </div>
+        <h1
+          style={{
+            fontSize: "24px",
+            fontWeight: 700,
+            color: "#2C1A10",
+            marginBottom: "8px",
+            fontFamily: "var(--font-space-grotesk, Space Grotesk, sans-serif)",
+          }}
+        >
+          Something went wrong
+        </h1>
+        <p
+          style={{
+            fontSize: "16px",
+            color: "#6B5A48",
+            marginBottom: "32px",
+            lineHeight: 1.5,
+          }}
+        >
+          An unexpected error occurred. Please try again or refresh the page.
+        </p>
+        <button
+          onClick={reset}
+          style={{
+            background: "#C84B1A",
+            color: "#FEFCF8",
+            border: "none",
+            borderRadius: "8px",
+            padding: "12px 32px",
+            fontSize: "16px",
+            fontWeight: 600,
+            cursor: "pointer",
+            fontFamily: "var(--font-inter, Inter, sans-serif)",
+          }}
+        >
+          Try again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/lib/roadmap-data.ts
+++ b/lib/roadmap-data.ts
@@ -653,7 +653,7 @@ export const ROADMAP: RoadmapBatch[] = [
           "Add root-level ErrorBoundary in layout.tsx and per-page error boundaries.",
           "Show 'Something went wrong' UI with retry button.",
         ].join("\n"),
-        status: "not-started",
+        status: "in-progress",
         tests: true,
         branch: "feat/error-boundaries",
         issue: 119,

--- a/tests/error-boundaries.test.tsx
+++ b/tests/error-boundaries.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, test, expect, vi } from "vitest";
+import RootError from "@/app/error";
+import AppError from "@/app/(app)/error";
+import AdminError from "@/app/(admin)/error";
+import CoachError from "@/app/(coach)/error";
+
+describe("Root error boundary", () => {
+  test("renders error message and retry button", () => {
+    const error = new Error("Test root error");
+    const reset = vi.fn();
+
+    render(<RootError error={error} reset={reset} />);
+
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Try again" })).toBeInTheDocument();
+  });
+
+  test("calls reset when retry button is clicked", () => {
+    const error = new Error("Test root error");
+    const reset = vi.fn();
+
+    render(<RootError error={error} reset={reset} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+
+  test("logs error to console", () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const error = new Error("Console test error");
+    const reset = vi.fn();
+
+    render(<RootError error={error} reset={reset} />);
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "Root error boundary caught:",
+      error
+    );
+    consoleSpy.mockRestore();
+  });
+});
+
+describe("App section error boundary", () => {
+  test("renders error message and retry button", () => {
+    const error = new Error("Test app error");
+    const reset = vi.fn();
+
+    render(<AppError error={error} reset={reset} />);
+
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    expect(
+      screen.getByText(/hit an error loading this page/i)
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Try again" })).toBeInTheDocument();
+  });
+
+  test("calls reset when retry button is clicked", () => {
+    const error = new Error("Test app error");
+    const reset = vi.fn();
+
+    render(<AppError error={error} reset={reset} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("Admin section error boundary", () => {
+  test("renders admin-specific error message", () => {
+    const error = new Error("Test admin error");
+    const reset = vi.fn();
+
+    render(<AdminError error={error} reset={reset} />);
+
+    expect(screen.getByText("Admin panel error")).toBeInTheDocument();
+    expect(
+      screen.getByText(/no changes were saved/i)
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Try again" })).toBeInTheDocument();
+  });
+
+  test("calls reset when retry button is clicked", () => {
+    const error = new Error("Test admin error");
+    const reset = vi.fn();
+
+    render(<AdminError error={error} reset={reset} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("Coach section error boundary", () => {
+  test("renders coach-specific error message", () => {
+    const error = new Error("Test coach error");
+    const reset = vi.fn();
+
+    render(<CoachError error={error} reset={reset} />);
+
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    expect(
+      screen.getByText(/coaching panel/i)
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Try again" })).toBeInTheDocument();
+  });
+
+  test("calls reset when retry button is clicked", () => {
+    const error = new Error("Test coach error");
+    const reset = vi.fn();
+
+    render(<CoachError error={error} reset={reset} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Added Next.js App Router `error.tsx` files for root, `(app)`, `(admin)`, and `(coach)` route groups
- Each error boundary renders a styled "Something went wrong" UI with a "Try again" button using the project's design tokens (parchment background, burnt orange CTA)
- All error boundaries log errors to console and call `reset()` on retry

## Test plan
- [x] `pnpm typecheck` passes cleanly
- [x] `pnpm test` passes (499 tests across 36 files)
- [x] Error boundary tests verify rendering, reset callback, and console logging
- [ ] Manual: trigger a runtime error in each route group and confirm the error UI appears instead of a white screen

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)