### PR TITLE
feat(11-2): Exercise reorder — use transaction instead of Promise.all

### DIFF
--- a/app/api/admin/programs/[programId]/session-editor/reorder/route.ts
+++ b/app/api/admin/programs/[programId]/session-editor/reorder/route.ts
@@ -17,21 +17,20 @@ export async function POST(
       return NextResponse.json({ error: 'Invalid input' }, { status: 400 });
     }
 
-    const { sessionId, exercises } = parsed.data;
+    const { exercises } = parsed.data;
 
     const supabase = await createClient();
 
-    // Update order_index for all exercises in batch
-    const updates = exercises.map(async ({ id, order_index }) => {
-      const { error } = await supabase
-        .from('template_exercises')
-        .update({ order_index })
-        .eq('id', id);
-      
-      if (error) throw error;
+    // Use RPC to update all exercise orders in a single database transaction.
+    // This prevents partial state if one update fails midway through.
+    const { error } = await supabase.rpc('reorder_exercises', {
+      exercise_orders: exercises.map(({ id, order_index }) => ({
+        id,
+        order_index,
+      })),
     });
 
-    await Promise.all(updates);
+    if (error) throw error;
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/lib/roadmap-data.ts
+++ b/lib/roadmap-data.ts
@@ -639,6 +639,7 @@ export const ROADMAP: RoadmapBatch[] = [
         status: "in-progress",
         tests: true,
         branch: "fix/exercise-reorder-transaction",
+        pr: 134,
         issue: 116,
         scope: {
           owns: ["app/api/admin/programs/"],

--- a/lib/roadmap-data.ts
+++ b/lib/roadmap-data.ts
@@ -636,7 +636,7 @@ export const ROADMAP: RoadmapBatch[] = [
           "Admin exercise reorder uses Promise.all with individual updates — partial state if one fails.",
           "Fix: use a Supabase RPC function that wraps the reorder in a database transaction.",
         ].join("\n"),
-        status: "not-started",
+        status: "in-progress",
         tests: true,
         branch: "fix/exercise-reorder-transaction",
         issue: 116,

--- a/supabase/migrations/006_reorder_exercises_rpc.sql
+++ b/supabase/migrations/006_reorder_exercises_rpc.sql
@@ -1,0 +1,17 @@
+-- Migration: Add reorder_exercises RPC function
+-- Wraps exercise reorder in a database transaction to prevent partial state
+-- when one update fails in a batch.
+
+CREATE OR REPLACE FUNCTION reorder_exercises(exercise_orders jsonb)
+RETURNS void AS $$
+DECLARE
+  item jsonb;
+BEGIN
+  FOR item IN SELECT * FROM jsonb_array_elements(exercise_orders)
+  LOOP
+    UPDATE template_exercises
+    SET order_index = (item->>'order_index')::int
+    WHERE id = (item->>'id')::uuid;
+  END LOOP;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -483,3 +483,20 @@ RETURNS TABLE (exercise_id uuid) AS $$
     AND status = 'locked_in'
     AND exercise_id = ANY(p_exercise_ids);
 $$ LANGUAGE sql SECURITY DEFINER STABLE;
+
+-- Reorder exercises atomically in a single transaction.
+-- Accepts a JSONB array of {id, order_index} objects and updates each
+-- template_exercises row. If any update fails, the entire batch rolls back.
+CREATE OR REPLACE FUNCTION reorder_exercises(exercise_orders jsonb)
+RETURNS void AS $$
+DECLARE
+  item jsonb;
+BEGIN
+  FOR item IN SELECT * FROM jsonb_array_elements(exercise_orders)
+  LOOP
+    UPDATE template_exercises
+    SET order_index = (item->>'order_index')::int
+    WHERE id = (item->>'id')::uuid;
+  END LOOP;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;

--- a/tests/exercise-reorder.test.ts
+++ b/tests/exercise-reorder.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// Track RPC calls for assertion
+const mockRpc = vi.fn(() => Promise.resolve({ data: null, error: null }));
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(() => ({
+    rpc: mockRpc,
+  })),
+}));
+
+vi.mock('@/lib/rbac', () => ({
+  requireRole: vi.fn(() => Promise.resolve()),
+}));
+
+// Import after mocks are defined
+import { POST } from '@/app/api/admin/programs/[programId]/session-editor/reorder/route';
+
+describe('Exercise Reorder API — Transaction Safety', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should call reorder_exercises RPC with correct payload', async () => {
+    const exercises = [
+      { id: 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a22', order_index: 1 },
+      { id: 'c0eebc99-9c0b-4ef8-bb6d-6bb9bd380a33', order_index: 0 },
+    ];
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/admin/programs/program-1/session-editor/reorder',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          sessionId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+          exercises,
+        }),
+      }
+    );
+
+    const params = Promise.resolve({ programId: 'program-1' });
+    const response = await POST(request, { params });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+
+    // Verify RPC was called instead of individual updates
+    expect(mockRpc).toHaveBeenCalledOnce();
+    expect(mockRpc).toHaveBeenCalledWith('reorder_exercises', {
+      exercise_orders: exercises,
+    });
+  });
+
+  it('should return 400 for missing exercises array', async () => {
+    const request = new NextRequest(
+      'http://localhost:3000/api/admin/programs/program-1/session-editor/reorder',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          sessionId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+          // missing exercises
+        }),
+      }
+    );
+
+    const params = Promise.resolve({ programId: 'program-1' });
+    const response = await POST(request, { params });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe('Invalid input');
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
+
+  it('should return 400 for empty exercises array', async () => {
+    const request = new NextRequest(
+      'http://localhost:3000/api/admin/programs/program-1/session-editor/reorder',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          sessionId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+          exercises: [],
+        }),
+      }
+    );
+
+    const params = Promise.resolve({ programId: 'program-1' });
+    const response = await POST(request, { params });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe('Invalid input');
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
+
+  it('should return 400 for invalid exercise ID format', async () => {
+    const request = new NextRequest(
+      'http://localhost:3000/api/admin/programs/program-1/session-editor/reorder',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          sessionId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+          exercises: [{ id: 'not-a-uuid', order_index: 0 }],
+        }),
+      }
+    );
+
+    const params = Promise.resolve({ programId: 'program-1' });
+    const response = await POST(request, { params });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe('Invalid input');
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
+
+  it('should return 400 for negative order_index', async () => {
+    const request = new NextRequest(
+      'http://localhost:3000/api/admin/programs/program-1/session-editor/reorder',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          sessionId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+          exercises: [
+            { id: 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a22', order_index: -1 },
+          ],
+        }),
+      }
+    );
+
+    const params = Promise.resolve({ programId: 'program-1' });
+    const response = await POST(request, { params });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe('Invalid input');
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
+
+  it('should return 500 when RPC fails', async () => {
+    mockRpc.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'database connection lost', code: '08006' } as never,
+    });
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/admin/programs/program-1/session-editor/reorder',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          sessionId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+          exercises: [
+            { id: 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a22', order_index: 0 },
+          ],
+        }),
+      }
+    );
+
+    const params = Promise.resolve({ programId: 'program-1' });
+    const response = await POST(request, { params });
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toBe('Failed to reorder exercises');
+  });
+
+  it('should handle a large batch of exercises', async () => {
+    const exercises = Array.from({ length: 50 }, (_, i) => ({
+      id: `${i.toString().padStart(8, '0')}-0000-4000-8000-000000000000`,
+      order_index: i,
+    }));
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/admin/programs/program-1/session-editor/reorder',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          sessionId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+          exercises,
+        }),
+      }
+    );
+
+    const params = Promise.resolve({ programId: 'program-1' });
+    const response = await POST(request, { params });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(mockRpc).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/session-editor-api.test.ts
+++ b/tests/session-editor-api.test.ts
@@ -35,7 +35,8 @@ vi.mock('@/lib/supabase/server', () => ({
           }))
         }))
       }))
-    }))
+    })),
+    rpc: vi.fn(() => Promise.resolve({ data: null, error: null }))
   }))
 }));
 


### PR DESCRIPTION
## Summary
- Replaced `Promise.all` with individual Supabase updates in the exercise reorder endpoint with a single `supabase.rpc('reorder_exercises', ...)` call that wraps all updates in a database transaction
- Added PostgreSQL function `reorder_exercises(exercise_orders jsonb)` via migration `006_reorder_exercises_rpc.sql` — uses `SECURITY DEFINER` and iterates a JSONB array to atomically update `order_index` on `template_exercises`
- Updated `supabase/schema.sql` with the function definition for reference
- Added comprehensive test suite in `tests/exercise-reorder.test.ts` covering valid input, validation errors, RPC failures, and large batch handling

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (497 tests across 36 files)
- [ ] Deploy migration `006_reorder_exercises_rpc.sql` to Supabase SQL Editor
- [ ] Manually test drag-and-drop reorder in admin session editor

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)