### PR TITLE
feat(12-1): Program enrollment UI — Assign Program button

### DIFF
--- a/app/(admin)/users/page.tsx
+++ b/app/(admin)/users/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Profile, UserRole, TemplateTier, Gender } from "@/lib/types";
+import { Profile, Program, UserRole, TemplateTier, Gender } from "@/lib/types";
 import { Button } from "@/components/ui/button";
 import {
   Table,
@@ -15,8 +15,9 @@ import { Select } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { toast } from "sonner";
-import { Edit, Save, X, Trash2, UserPlus } from "lucide-react";
+import { Edit, Save, X, Trash2, UserPlus, ClipboardList } from "lucide-react";
 import Link from "next/link";
+import { apiFetchJson } from "@/lib/api-helpers";
 
 interface ProfileWithCoach extends Profile {
   coach?: { id: string; full_name: string; email: string } | null;
@@ -25,12 +26,16 @@ interface ProfileWithCoach extends Profile {
 export default function AdminUsersPage() {
   const [users, setUsers] = useState<ProfileWithCoach[]>([]);
   const [coaches, setCoaches] = useState<ProfileWithCoach[]>([]);
+  const [programs, setPrograms] = useState<Program[]>([]);
   const [loading, setLoading] = useState(true);
   const [editingUser, setEditingUser] = useState<string | null>(null);
   const [editForm, setEditForm] = useState<Partial<Profile>>({});
+  const [enrollingUser, setEnrollingUser] = useState<string | null>(null);
+  const [enrolling, setEnrolling] = useState(false);
 
   useEffect(() => {
     fetchUsers();
+    fetchPrograms();
   }, []);
 
   const fetchUsers = async () => {
@@ -47,6 +52,33 @@ export default function AdminUsersPage() {
       toast.error("Failed to load users");
     } finally {
       setLoading(false);
+    }
+  };
+
+  const fetchPrograms = async () => {
+    try {
+      const data = await apiFetchJson<Program[]>("/api/admin/programs");
+      setPrograms(data.filter((p) => p.is_active));
+    } catch (error) {
+      console.error("Error fetching programs:", error);
+    }
+  };
+
+  const handleEnroll = async (userId: string, programId: string) => {
+    setEnrolling(true);
+    try {
+      await apiFetchJson("/api/admin/enroll", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userId, programId }),
+      });
+      toast.success("Program assigned successfully");
+      setEnrollingUser(null);
+    } catch (error) {
+      console.error("Error enrolling user:", error);
+      toast.error("Failed to assign program");
+    } finally {
+      setEnrolling(false);
     }
   };
 
@@ -280,7 +312,7 @@ export default function AdminUsersPage() {
                     {new Date(user.created_at).toLocaleDateString()}
                   </TableCell>
                   <TableCell>
-                    <div style={{ display: "flex", gap: 8 }}>
+                    <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
                       {editingUser === user.id ? (
                         <>
                           <Button
@@ -299,6 +331,37 @@ export default function AdminUsersPage() {
                             <X className="h-4 w-4" />
                           </Button>
                         </>
+                      ) : enrollingUser === user.id ? (
+                        <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                          <Select
+                            defaultValue=""
+                            onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
+                              if (e.target.value) {
+                                handleEnroll(user.id, e.target.value);
+                              }
+                            }}
+                            className="w-36 text-sm"
+                            disabled={enrolling}
+                          >
+                            <option value="" disabled>
+                              Select program
+                            </option>
+                            {programs.map((program) => (
+                              <option key={program.id} value={program.id}>
+                                {program.name}
+                              </option>
+                            ))}
+                          </Select>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => setEnrollingUser(null)}
+                            className="h-8 w-8 p-0"
+                            disabled={enrolling}
+                          >
+                            <X className="h-4 w-4" />
+                          </Button>
+                        </div>
                       ) : (
                         <>
                           <Button
@@ -309,6 +372,18 @@ export default function AdminUsersPage() {
                           >
                             <Edit className="h-4 w-4" />
                           </Button>
+                          {user.role === "user" && (
+                            <Button
+                              size="sm"
+                              onClick={() => setEnrollingUser(user.id)}
+                              className="h-8 px-2 text-xs"
+                              style={{ backgroundColor: "#C84B1A", color: "#FEFCF8" }}
+                              title="Assign Program"
+                            >
+                              <ClipboardList className="h-4 w-4 mr-1" />
+                              Assign
+                            </Button>
+                          )}
                           <Button
                             size="sm"
                             variant="outline"

--- a/app/api/admin/enroll/route.ts
+++ b/app/api/admin/enroll/route.ts
@@ -1,0 +1,80 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+import { enrollUserSchema } from "@/lib/validations/admin";
+
+export async function POST(request: Request) {
+  try {
+    const supabase = await createClient();
+
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // Verify admin role
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("role")
+      .eq("id", user.id)
+      .single();
+
+    if (!profile || profile.role !== "admin") {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const body = await request.json();
+    const parsed = enrollUserSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid input" }, { status: 400 });
+    }
+
+    const { userId, programId } = parsed.data;
+
+    // Fetch the user's profile to get template_tier and gender
+    const { data: targetProfile, error: profileError } = await supabase
+      .from("profiles")
+      .select("template_tier, gender")
+      .eq("id", userId)
+      .single();
+
+    if (profileError || !targetProfile) {
+      console.error("Error fetching target profile:", profileError);
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    // Deactivate any current active enrollment for the user
+    const { error: deactivateError } = await supabase
+      .from("user_enrollments")
+      .update({ is_active: false })
+      .eq("user_id", userId)
+      .eq("is_active", true);
+
+    if (deactivateError) {
+      console.error("Error deactivating enrollments:", deactivateError);
+      return NextResponse.json({ error: "Failed to deactivate current enrollment" }, { status: 500 });
+    }
+
+    // Create new enrollment
+    const { data: enrollment, error: insertError } = await supabase
+      .from("user_enrollments")
+      .insert({
+        user_id: userId,
+        program_id: programId,
+        is_active: true,
+        template_tier: targetProfile.template_tier,
+        gender_applied: targetProfile.gender === "unset" ? "other" : targetProfile.gender,
+      })
+      .select()
+      .single();
+
+    if (insertError) {
+      console.error("Error creating enrollment:", insertError);
+      return NextResponse.json({ error: "Failed to create enrollment" }, { status: 500 });
+    }
+
+    return NextResponse.json(enrollment);
+  } catch (error) {
+    console.error("Error in POST /api/admin/enroll:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/lib/roadmap-data.ts
+++ b/lib/roadmap-data.ts
@@ -681,7 +681,7 @@ export const ROADMAP: RoadmapBatch[] = [
           "New endpoint: POST /api/admin/enroll { userId, programId }.",
           "Deactivates current enrollment, creates new user_enrollments row.",
         ].join("\n"),
-        status: "not-started",
+        status: "in-progress",
         tests: true,
         branch: "feat/program-enrollment-ui",
         issue: 106,

--- a/lib/validations/admin.ts
+++ b/lib/validations/admin.ts
@@ -167,3 +167,10 @@ export const upsertOverrideSchema = z.object({
 export const deleteOverrideSchema = z.object({
   id: uuidSchema,
 });
+
+// ─── Enrollment (POST /api/admin/enroll) ────────────────────────────────────
+
+export const enrollUserSchema = z.object({
+  userId: uuidSchema,
+  programId: uuidSchema,
+});

--- a/tests/admin-enroll.test.ts
+++ b/tests/admin-enroll.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { POST } from "@/app/api/admin/enroll/route";
+
+const mockSupabase = {
+  auth: { getUser: vi.fn() },
+  from: vi.fn().mockReturnThis(),
+  select: vi.fn().mockReturnThis(),
+  insert: vi.fn().mockReturnThis(),
+  update: vi.fn().mockReturnThis(),
+  eq: vi.fn().mockReturnThis(),
+  single: vi.fn(),
+};
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: () => mockSupabase,
+}));
+
+function makeRequest(body: Record<string, unknown>) {
+  return new Request("http://localhost/api/admin/enroll", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const VALID_USER_ID = "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11";
+const VALID_PROGRAM_ID = "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a22";
+
+describe("POST /api/admin/enroll", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSupabase.from.mockReturnThis();
+    mockSupabase.select.mockReturnThis();
+    mockSupabase.insert.mockReturnThis();
+    mockSupabase.update.mockReturnThis();
+    mockSupabase.eq.mockReturnThis();
+  });
+
+  it("should return 401 if not authenticated", async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: null } });
+
+    const response = await POST(makeRequest({ userId: VALID_USER_ID, programId: VALID_PROGRAM_ID }));
+    expect(response.status).toBe(401);
+  });
+
+  it("should return 403 if user is not admin", async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+    mockSupabase.single.mockResolvedValueOnce({ data: { role: "user" }, error: null });
+
+    const response = await POST(makeRequest({ userId: VALID_USER_ID, programId: VALID_PROGRAM_ID }));
+    expect(response.status).toBe(403);
+  });
+
+  it("should return 400 if userId is missing", async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: "admin-1" } } });
+    mockSupabase.single.mockResolvedValueOnce({ data: { role: "admin" }, error: null });
+
+    const response = await POST(makeRequest({ programId: VALID_PROGRAM_ID }));
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toBe("Invalid input");
+  });
+
+  it("should return 400 if programId is missing", async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: "admin-1" } } });
+    mockSupabase.single.mockResolvedValueOnce({ data: { role: "admin" }, error: null });
+
+    const response = await POST(makeRequest({ userId: VALID_USER_ID }));
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toBe("Invalid input");
+  });
+
+  it("should return 400 if userId is not a valid UUID", async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: "admin-1" } } });
+    mockSupabase.single.mockResolvedValueOnce({ data: { role: "admin" }, error: null });
+
+    const response = await POST(makeRequest({ userId: "not-a-uuid", programId: VALID_PROGRAM_ID }));
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toBe("Invalid input");
+  });
+
+  it("should enroll user successfully", async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: "admin-1" } } });
+    // 1st single: admin role check
+    mockSupabase.single
+      .mockResolvedValueOnce({ data: { role: "admin" }, error: null })
+      // 2nd single: target user profile
+      .mockResolvedValueOnce({ data: { template_tier: "default", gender: "male" }, error: null })
+      // 3rd single: inserted enrollment
+      .mockResolvedValueOnce({
+        data: {
+          id: "enroll-1",
+          user_id: VALID_USER_ID,
+          program_id: VALID_PROGRAM_ID,
+          is_active: true,
+          template_tier: "default",
+          gender_applied: "male",
+        },
+        error: null,
+      });
+
+    // Deactivate step: .update().eq().eq() — the second eq resolves
+    mockSupabase.eq
+      .mockReturnValueOnce(mockSupabase) // .eq("id", user.id) for profile select
+      .mockReturnValueOnce(mockSupabase) // .eq("id", userId) for target profile select
+      .mockReturnValueOnce(mockSupabase) // .eq("user_id", userId) for deactivate
+      .mockResolvedValueOnce({ error: null }); // .eq("is_active", true) for deactivate — resolves
+
+    const response = await POST(makeRequest({ userId: VALID_USER_ID, programId: VALID_PROGRAM_ID }));
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.id).toBe("enroll-1");
+    expect(data.is_active).toBe(true);
+    expect(data.user_id).toBe(VALID_USER_ID);
+    expect(data.program_id).toBe(VALID_PROGRAM_ID);
+  });
+});


### PR DESCRIPTION
## Summary
- Added `POST /api/admin/enroll` endpoint that accepts `{ userId, programId }`, validates with Zod, deactivates any current active enrollment, and creates a new `user_enrollments` row with the user's template_tier and gender.
- Added "Assign" button (burnt orange CTA) to each user row on the admin users page. Clicking it reveals a program dropdown; selecting a program triggers enrollment via `apiFetchJson` with `sonner` toast feedback.
- Added `enrollUserSchema` validation to `lib/validations/admin.ts`.
- Added tests in `tests/admin-enroll.test.ts` covering valid enrollment, missing userId (400), missing programId (400), invalid UUID (400), auth (401), and role checks (403).
- Updated `lib/roadmap-data.ts` item `12-1` status to `in-progress`.

## Test plan
- [x] `pnpm tsc --noEmit` passes cleanly
- [x] `pnpm test` — all 496 tests pass (36 test files)
- [ ] Manual: navigate to /admin/users, click "Assign" on a user row, select a program, verify toast and enrollment created
- [ ] Manual: verify previous active enrollment is deactivated when a new one is assigned

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)