### PR TITLE
feat(12-4): Session history view

### DIFF
--- a/app/(app)/sessions/history/page.tsx
+++ b/app/(app)/sessions/history/page.tsx
@@ -1,0 +1,385 @@
+import { createClient } from "@/lib/supabase/server";
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { ChevronLeft, ChevronRight, Calendar, Dumbbell, Clock } from "lucide-react";
+import { EFFORT_LABELS } from "@/lib/constants";
+
+interface SearchParams {
+  page?: string;
+}
+
+interface SessionHistoryPageProps {
+  searchParams: Promise<SearchParams>;
+}
+
+interface SetLogEntry {
+  id: string;
+  session_log_id: string;
+  set_number: number;
+  weight_used: number | null;
+  reps_completed: number | null;
+  is_completed: boolean;
+  exercises: {
+    id: string;
+    name: string;
+  } | null;
+}
+
+interface SessionEntry {
+  id: string;
+  workout_template_id: string;
+  week_number: number;
+  session_number: number;
+  started_at: string | null;
+  completed_at: string | null;
+  is_complete: boolean;
+  post_session_effort: number | null;
+  pre_session_soreness: number | null;
+  notes: string | null;
+  workout_templates: {
+    id: string;
+    day_label: string;
+    title: string;
+  } | null;
+  set_logs: SetLogEntry[];
+}
+
+interface HistoryResponse {
+  sessions: SessionEntry[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+function formatDate(dateStr: string): string {
+  const date = new Date(dateStr);
+  return date.toLocaleDateString("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function formatTime(dateStr: string): string {
+  const date = new Date(dateStr);
+  return date.toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+/** Group set logs by exercise, preserving set order */
+function groupSetsByExercise(
+  setLogs: SetLogEntry[]
+): { exerciseName: string; sets: SetLogEntry[] }[] {
+  const grouped: Map<string, { exerciseName: string; sets: SetLogEntry[] }> =
+    new Map();
+
+  for (const log of setLogs) {
+    const name = log.exercises?.name ?? "Unknown Exercise";
+    const exerciseId = log.exercises?.id ?? log.id;
+    const key = exerciseId;
+
+    if (!grouped.has(key)) {
+      grouped.set(key, { exerciseName: name, sets: [] });
+    }
+    grouped.get(key)!.sets.push(log);
+  }
+
+  return Array.from(grouped.values());
+}
+
+function SessionCard({ session }: { session: SessionEntry }) {
+  const exercises = groupSetsByExercise(session.set_logs);
+  const effortLabel = session.post_session_effort
+    ? EFFORT_LABELS[session.post_session_effort]
+    : null;
+
+  return (
+    <div className="bg-bg-elevated rounded-xl border border-border-subtle p-5">
+      {/* Header */}
+      <div className="flex items-start justify-between mb-4">
+        <div>
+          <h3 className="text-base font-semibold text-content-primary font-display">
+            {session.workout_templates?.title ?? `Session ${session.session_number}`}
+          </h3>
+          <div className="flex items-center gap-3 mt-1 text-sm text-content-secondary">
+            <span className="flex items-center gap-1">
+              <Calendar className="w-3.5 h-3.5" />
+              {session.completed_at ? formatDate(session.completed_at) : "N/A"}
+            </span>
+            {session.completed_at && (
+              <span className="flex items-center gap-1">
+                <Clock className="w-3.5 h-3.5" />
+                {formatTime(session.completed_at)}
+              </span>
+            )}
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          {session.workout_templates?.day_label && (
+            <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-bg-hover text-content-secondary">
+              Day {session.workout_templates.day_label}
+            </span>
+          )}
+          <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-bg-hover text-content-secondary">
+            Week {session.week_number}
+          </span>
+        </div>
+      </div>
+
+      {/* Effort badge */}
+      {effortLabel && (
+        <div className="mb-3">
+          <span
+            className="text-xs font-medium px-2 py-0.5 rounded-full"
+            style={{
+              backgroundColor: `${effortLabel.color}20`,
+              color: effortLabel.color,
+            }}
+          >
+            {effortLabel.emoji} Effort: {effortLabel.label}
+          </span>
+        </div>
+      )}
+
+      {/* Exercise breakdown */}
+      {exercises.length > 0 ? (
+        <div className="space-y-3">
+          {exercises.map((group) => (
+            <div key={group.exerciseName}>
+              <div className="flex items-center gap-1.5 mb-1">
+                <Dumbbell className="w-3.5 h-3.5 text-content-muted" />
+                <span className="text-sm font-medium text-content-primary">
+                  {group.exerciseName}
+                </span>
+              </div>
+              <div className="flex flex-wrap gap-2 ml-5">
+                {group.sets.map((set) => (
+                  <span
+                    key={set.id}
+                    className="text-xs px-2 py-1 rounded-md bg-bg-hover text-content-secondary"
+                  >
+                    {set.weight_used != null ? `${set.weight_used} lbs` : "BW"}{" "}
+                    x {set.reps_completed ?? 0}
+                  </span>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="text-sm text-content-muted italic">No set data recorded</p>
+      )}
+
+      {/* Notes */}
+      {session.notes && (
+        <p className="mt-3 text-xs text-content-secondary border-t border-border-subtle pt-3">
+          {session.notes}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default async function SessionHistoryPage({
+  searchParams,
+}: SessionHistoryPageProps) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect("/login");
+
+  const resolvedParams = await searchParams;
+  const page = Math.max(1, parseInt(resolvedParams.page || "1", 10));
+  const limit = 20;
+
+  // Fetch from internal API
+  const baseUrl =
+    process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
+
+  // Instead of calling our own API (which would require auth cookies forwarding),
+  // query Supabase directly in this server component — same pattern as sessions/page.tsx
+
+  // Count total completed sessions
+  const { count, error: countError } = await supabase
+    .from("session_logs")
+    .select("id", { count: "exact", head: true })
+    .eq("user_id", user.id)
+    .eq("is_complete", true);
+
+  const total = count ?? 0;
+  const offset = (page - 1) * limit;
+
+  // Fetch paginated sessions
+  const { data: sessions, error: sessionsError } = await supabase
+    .from("session_logs")
+    .select(
+      `
+      id,
+      workout_template_id,
+      week_number,
+      session_number,
+      started_at,
+      completed_at,
+      is_complete,
+      post_session_effort,
+      pre_session_soreness,
+      notes,
+      workout_templates (
+        id,
+        day_label,
+        title
+      )
+    `
+    )
+    .eq("user_id", user.id)
+    .eq("is_complete", true)
+    .order("completed_at", { ascending: false })
+    .range(offset, offset + limit - 1);
+
+  let setLogs: SetLogEntry[] = [];
+  if (sessions && sessions.length > 0) {
+    const sessionIds = sessions.map((s) => s.id);
+    const { data: fetchedSetLogs } = await supabase
+      .from("set_logs")
+      .select(
+        `
+        id,
+        session_log_id,
+        set_number,
+        weight_used,
+        reps_completed,
+        is_completed,
+        exercises (
+          id,
+          name
+        )
+      `
+      )
+      .in("session_log_id", sessionIds)
+      .eq("is_completed", true)
+      .order("set_number", { ascending: true });
+
+    setLogs = (fetchedSetLogs as unknown as SetLogEntry[]) ?? [];
+  }
+
+  // Group set_logs by session
+  const setLogsBySession: Record<string, SetLogEntry[]> = {};
+  for (const log of setLogs) {
+    if (!setLogsBySession[log.session_log_id]) {
+      setLogsBySession[log.session_log_id] = [];
+    }
+    setLogsBySession[log.session_log_id].push(log);
+  }
+
+  const enrichedSessions: SessionEntry[] = (sessions ?? []).map((session) => ({
+    ...(session as unknown as SessionEntry),
+    set_logs: setLogsBySession[session.id] ?? [],
+  }));
+
+  const totalPages = Math.max(1, Math.ceil(total / limit));
+  const hasError = !!countError || !!sessionsError;
+
+  return (
+    <div>
+      {/* Header */}
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <div className="flex items-center gap-2 mb-1">
+            <Link
+              href="/sessions"
+              className="text-content-secondary hover:text-content-primary transition-colors"
+            >
+              <ChevronLeft className="w-5 h-5" />
+            </Link>
+            <h1 className="text-2xl font-bold text-content-primary font-display">
+              Session History
+            </h1>
+          </div>
+          <p className="text-sm text-content-secondary ml-7">
+            {total} completed {total === 1 ? "session" : "sessions"}
+          </p>
+        </div>
+      </div>
+
+      {/* Error state */}
+      {hasError && (
+        <div className="text-center py-8">
+          <p className="text-content-secondary mb-4">
+            Unable to load your session history. Please try again later.
+          </p>
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!hasError && enrichedSessions.length === 0 && (
+        <div className="text-center py-16">
+          <Dumbbell className="w-12 h-12 text-content-muted mx-auto mb-4" />
+          <h2 className="text-lg font-semibold text-content-primary mb-2">
+            No completed sessions yet
+          </h2>
+          <p className="text-sm text-content-secondary mb-6">
+            Complete your first workout to see it here.
+          </p>
+          <Link
+            href="/sessions"
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-colors"
+            style={{ backgroundColor: "#C84B1A", color: "#FEFCF8" }}
+          >
+            Go to Sessions
+          </Link>
+        </div>
+      )}
+
+      {/* Session list */}
+      {!hasError && enrichedSessions.length > 0 && (
+        <div className="space-y-4">
+          {enrichedSessions.map((session) => (
+            <SessionCard key={session.id} session={session} />
+          ))}
+        </div>
+      )}
+
+      {/* Pagination */}
+      {!hasError && totalPages > 1 && (
+        <div className="flex justify-between items-center mt-8 pt-6 border-t border-border-subtle">
+          <Link
+            href={`/sessions/history?page=${Math.max(1, page - 1)}`}
+            className={`flex items-center gap-1 text-sm px-3 py-2 rounded-md transition-colors ${
+              page === 1
+                ? "text-content-muted pointer-events-none"
+                : "text-content-secondary hover:text-content-primary hover:bg-bg-hover"
+            }`}
+            aria-disabled={page === 1}
+            tabIndex={page === 1 ? -1 : undefined}
+          >
+            <ChevronLeft className="w-4 h-4" />
+            Previous
+          </Link>
+
+          <span className="text-sm text-content-secondary">
+            Page {page} of {totalPages}
+          </span>
+
+          <Link
+            href={`/sessions/history?page=${Math.min(totalPages, page + 1)}`}
+            className={`flex items-center gap-1 text-sm px-3 py-2 rounded-md transition-colors ${
+              page === totalPages
+                ? "text-content-muted pointer-events-none"
+                : "text-content-secondary hover:text-content-primary hover:bg-bg-hover"
+            }`}
+            aria-disabled={page === totalPages}
+            tabIndex={page === totalPages ? -1 : undefined}
+          >
+            Next
+            <ChevronRight className="w-4 h-4" />
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(app)/sessions/page.tsx
+++ b/app/(app)/sessions/page.tsx
@@ -1,6 +1,8 @@
 import { Suspense } from "react";
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
+import Link from "next/link";
+import { History } from "lucide-react";
 import SessionCard from "./SessionCard";
 
 interface SearchParams {
@@ -133,6 +135,13 @@ export default async function SessionsPage({ searchParams }: SessionsPageProps) 
             Week {currentWeek} • Track your workouts and progress
           </p>
         </div>
+        <Link
+          href="/sessions/history"
+          className="flex items-center gap-1.5 text-sm font-medium px-3 py-2 rounded-lg text-content-secondary hover:text-content-primary hover:bg-bg-hover transition-colors"
+        >
+          <History className="w-4 h-4" />
+          History
+        </Link>
       </div>
 
       <Suspense fallback={<div className="text-content-secondary">Loading sessions...</div>}>

--- a/app/api/sessions/history/route.ts
+++ b/app/api/sessions/history/route.ts
@@ -1,0 +1,136 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+/**
+ * GET /api/sessions/history?page=1&limit=20
+ *
+ * Returns completed session_logs for the authenticated user,
+ * ordered by completed_at DESC, with their set_logs joined.
+ */
+export async function GET(request: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { searchParams } = request.nextUrl;
+  const page = Math.max(1, parseInt(searchParams.get("page") || "1", 10));
+  const limit = Math.min(50, Math.max(1, parseInt(searchParams.get("limit") || "20", 10)));
+  const offset = (page - 1) * limit;
+
+  // Count total completed sessions for pagination metadata
+  const { count, error: countError } = await supabase
+    .from("session_logs")
+    .select("id", { count: "exact", head: true })
+    .eq("user_id", user.id)
+    .eq("is_complete", true);
+
+  if (countError) {
+    console.error("[sessions/history/GET] count error:", countError);
+    return NextResponse.json(
+      { error: "Failed to fetch session history" },
+      { status: 500 }
+    );
+  }
+
+  const total = count ?? 0;
+
+  // Fetch paginated completed sessions with workout template info
+  const { data: sessions, error: sessionsError } = await supabase
+    .from("session_logs")
+    .select(
+      `
+      id,
+      workout_template_id,
+      week_number,
+      session_number,
+      started_at,
+      completed_at,
+      is_complete,
+      post_session_effort,
+      pre_session_soreness,
+      notes,
+      workout_templates (
+        id,
+        day_label,
+        title
+      )
+    `
+    )
+    .eq("user_id", user.id)
+    .eq("is_complete", true)
+    .order("completed_at", { ascending: false })
+    .range(offset, offset + limit - 1);
+
+  if (sessionsError) {
+    console.error("[sessions/history/GET] sessions error:", sessionsError);
+    return NextResponse.json(
+      { error: "Failed to fetch session history" },
+      { status: 500 }
+    );
+  }
+
+  if (!sessions || sessions.length === 0) {
+    return NextResponse.json({
+      sessions: [],
+      total,
+      page,
+      limit,
+    });
+  }
+
+  // Fetch set_logs for all returned sessions, joined with exercise names
+  const sessionIds = sessions.map((s) => s.id);
+  const { data: setLogs, error: setLogsError } = await supabase
+    .from("set_logs")
+    .select(
+      `
+      id,
+      session_log_id,
+      set_number,
+      weight_used,
+      reps_completed,
+      is_completed,
+      exercises (
+        id,
+        name
+      )
+    `
+    )
+    .in("session_log_id", sessionIds)
+    .eq("is_completed", true)
+    .order("set_number", { ascending: true });
+
+  if (setLogsError) {
+    console.error("[sessions/history/GET] set_logs error:", setLogsError);
+    // Non-fatal — return sessions without set details
+  }
+
+  // Group set_logs by session_log_id
+  const setLogsBySession: Record<string, NonNullable<typeof setLogs>> = {};
+  if (setLogs) {
+    for (const log of setLogs) {
+      if (!setLogsBySession[log.session_log_id]) {
+        setLogsBySession[log.session_log_id] = [];
+      }
+      setLogsBySession[log.session_log_id].push(log);
+    }
+  }
+
+  // Combine sessions with their set_logs
+  const enrichedSessions = sessions.map((session) => ({
+    ...session,
+    set_logs: setLogsBySession[session.id] ?? [],
+  }));
+
+  return NextResponse.json({
+    sessions: enrichedSessions,
+    total,
+    page,
+    limit,
+  });
+}

--- a/lib/roadmap-data.ts
+++ b/lib/roadmap-data.ts
@@ -734,7 +734,7 @@ export const ROADMAP: RoadmapBatch[] = [
           "New page: session history in reverse chronological order with sets/reps/weight.",
           "Backend: GET /api/sessions/history?page=1&limit=20 (paginated).",
         ].join("\n"),
-        status: "not-started",
+        status: "in-progress",
         tests: true,
         branch: "feat/session-history",
         issue: 110,

--- a/tests/session-history.test.ts
+++ b/tests/session-history.test.ts
@@ -1,0 +1,356 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Supabase mock ─────────────────────────────────────────────────────────────
+
+const mockSupabaseClient: any = {
+  auth: {
+    getUser: vi.fn(),
+  },
+  from: vi.fn(),
+};
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() => Promise.resolve(mockSupabaseClient)),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Build a fluent Supabase query mock that resolves with the given result */
+function buildSelectChain(result: { data: any; error: any; count?: number | null }) {
+  const terminal: any = {
+    ...result,
+    then: (resolve: any) => resolve(result),
+  };
+
+  // Build chainable methods from the bottom up
+  const makeChainable = (res: any): any => {
+    const chain: any = {};
+    const methods = ["select", "eq", "in", "order", "range", "single", "limit"];
+    for (const m of methods) {
+      chain[m] = vi.fn(() => makeChainable(res));
+    }
+    // When awaited, resolve with the result
+    chain.then = (resolve: any) => resolve(res);
+    // Allow count option on select
+    return chain;
+  };
+
+  return makeChainable(result);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("Session History API — GET /api/sessions/history", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  test("returns 401 when user is not authenticated", async () => {
+    mockSupabaseClient.auth.getUser.mockResolvedValue({
+      data: { user: null },
+    });
+
+    const { GET } = await import("@/app/api/sessions/history/route");
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/sessions/history"
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error).toBe("Unauthorized");
+  });
+
+  test("returns empty sessions array when user has no completed sessions", async () => {
+    mockSupabaseClient.auth.getUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+
+    // Count query returns 0
+    const countChain = buildSelectChain({ data: null, error: null, count: 0 });
+    // Sessions query returns empty array
+    const sessionsChain = buildSelectChain({ data: [], error: null });
+
+    mockSupabaseClient.from
+      .mockReturnValueOnce(countChain) // count query
+      .mockReturnValueOnce(sessionsChain); // sessions query
+
+    const { GET } = await import("@/app/api/sessions/history/route");
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/sessions/history"
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.sessions).toEqual([]);
+    expect(data.total).toBe(0);
+    expect(data.page).toBe(1);
+    expect(data.limit).toBe(20);
+  });
+
+  test("respects page and limit query parameters", async () => {
+    mockSupabaseClient.auth.getUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+
+    const countChain = buildSelectChain({ data: null, error: null, count: 45 });
+    const sessionsChain = buildSelectChain({ data: [], error: null });
+
+    mockSupabaseClient.from
+      .mockReturnValueOnce(countChain)
+      .mockReturnValueOnce(sessionsChain);
+
+    const { GET } = await import("@/app/api/sessions/history/route");
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/sessions/history?page=3&limit=10"
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.page).toBe(3);
+    expect(data.limit).toBe(10);
+    expect(data.total).toBe(45);
+  });
+
+  test("clamps limit to maximum of 50", async () => {
+    mockSupabaseClient.auth.getUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+
+    const countChain = buildSelectChain({ data: null, error: null, count: 0 });
+    const sessionsChain = buildSelectChain({ data: [], error: null });
+
+    mockSupabaseClient.from
+      .mockReturnValueOnce(countChain)
+      .mockReturnValueOnce(sessionsChain);
+
+    const { GET } = await import("@/app/api/sessions/history/route");
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/sessions/history?limit=200"
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.limit).toBe(50);
+  });
+
+  test("defaults page to 1 when negative value provided", async () => {
+    mockSupabaseClient.auth.getUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+
+    const countChain = buildSelectChain({ data: null, error: null, count: 0 });
+    const sessionsChain = buildSelectChain({ data: [], error: null });
+
+    mockSupabaseClient.from
+      .mockReturnValueOnce(countChain)
+      .mockReturnValueOnce(sessionsChain);
+
+    const { GET } = await import("@/app/api/sessions/history/route");
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/sessions/history?page=-5"
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.page).toBe(1);
+  });
+
+  test("returns 500 when count query fails", async () => {
+    mockSupabaseClient.auth.getUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+
+    const countChain = buildSelectChain({
+      data: null,
+      error: { message: "DB error" },
+      count: null,
+    });
+
+    mockSupabaseClient.from.mockReturnValueOnce(countChain);
+
+    const { GET } = await import("@/app/api/sessions/history/route");
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/sessions/history"
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toBe("Failed to fetch session history");
+  });
+
+  test("returns sessions with set_logs when data exists", async () => {
+    mockSupabaseClient.auth.getUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+
+    const countChain = buildSelectChain({ data: null, error: null, count: 1 });
+
+    const sessionData = [
+      {
+        id: "session-1",
+        workout_template_id: "wt-1",
+        week_number: 2,
+        session_number: 4,
+        started_at: "2025-01-10T09:00:00Z",
+        completed_at: "2025-01-10T10:00:00Z",
+        is_complete: true,
+        post_session_effort: 3,
+        pre_session_soreness: 4,
+        notes: null,
+        workout_templates: {
+          id: "wt-1",
+          day_label: "A",
+          title: "Upper Body Strength",
+        },
+      },
+    ];
+    const sessionsChain = buildSelectChain({
+      data: sessionData,
+      error: null,
+    });
+
+    const setLogData = [
+      {
+        id: "set-1",
+        session_log_id: "session-1",
+        set_number: 1,
+        weight_used: 135,
+        reps_completed: 8,
+        is_completed: true,
+        exercises: { id: "ex-1", name: "Bench Press" },
+      },
+      {
+        id: "set-2",
+        session_log_id: "session-1",
+        set_number: 2,
+        weight_used: 135,
+        reps_completed: 7,
+        is_completed: true,
+        exercises: { id: "ex-1", name: "Bench Press" },
+      },
+    ];
+    const setLogsChain = buildSelectChain({
+      data: setLogData,
+      error: null,
+    });
+
+    mockSupabaseClient.from
+      .mockReturnValueOnce(countChain)
+      .mockReturnValueOnce(sessionsChain)
+      .mockReturnValueOnce(setLogsChain);
+
+    const { GET } = await import("@/app/api/sessions/history/route");
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/sessions/history"
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.sessions).toHaveLength(1);
+    expect(data.sessions[0].id).toBe("session-1");
+    expect(data.sessions[0].workout_templates.title).toBe(
+      "Upper Body Strength"
+    );
+    expect(data.sessions[0].set_logs).toHaveLength(2);
+    expect(data.sessions[0].set_logs[0].weight_used).toBe(135);
+    expect(data.sessions[0].set_logs[0].exercises.name).toBe("Bench Press");
+    expect(data.total).toBe(1);
+  });
+});
+
+describe("Session History — Pagination Logic", () => {
+  test("calculates correct offset for each page", () => {
+    const limit = 20;
+
+    const page1Offset = (1 - 1) * limit;
+    expect(page1Offset).toBe(0);
+
+    const page2Offset = (2 - 1) * limit;
+    expect(page2Offset).toBe(20);
+
+    const page3Offset = (3 - 1) * limit;
+    expect(page3Offset).toBe(40);
+  });
+
+  test("calculates total pages correctly", () => {
+    const limit = 20;
+
+    expect(Math.ceil(0 / limit)).toBe(0);
+    expect(Math.ceil(1 / limit)).toBe(1);
+    expect(Math.ceil(20 / limit)).toBe(1);
+    expect(Math.ceil(21 / limit)).toBe(2);
+    expect(Math.ceil(100 / limit)).toBe(5);
+  });
+
+  test("clamps page number to valid range", () => {
+    expect(Math.max(1, -1)).toBe(1);
+    expect(Math.max(1, 0)).toBe(1);
+    expect(Math.max(1, 1)).toBe(1);
+    expect(Math.max(1, 5)).toBe(5);
+  });
+
+  test("clamps limit to valid range (1–50)", () => {
+    const clampLimit = (n: number) => Math.min(50, Math.max(1, n));
+
+    expect(clampLimit(-10)).toBe(1);
+    expect(clampLimit(0)).toBe(1);
+    expect(clampLimit(1)).toBe(1);
+    expect(clampLimit(20)).toBe(20);
+    expect(clampLimit(50)).toBe(50);
+    expect(clampLimit(100)).toBe(50);
+  });
+});
+
+describe("Session History — Set Log Grouping", () => {
+  test("groups set logs by exercise name", () => {
+    const setLogs = [
+      { exercises: { id: "ex-1", name: "Bench Press" }, set_number: 1 },
+      { exercises: { id: "ex-1", name: "Bench Press" }, set_number: 2 },
+      { exercises: { id: "ex-2", name: "Squat" }, set_number: 1 },
+    ];
+
+    const grouped: Map<string, any[]> = new Map();
+    for (const log of setLogs) {
+      const key = log.exercises?.id ?? "unknown";
+      if (!grouped.has(key)) grouped.set(key, []);
+      grouped.get(key)!.push(log);
+    }
+
+    expect(grouped.size).toBe(2);
+    expect(grouped.get("ex-1")).toHaveLength(2);
+    expect(grouped.get("ex-2")).toHaveLength(1);
+  });
+
+  test("handles set logs with missing exercise data", () => {
+    const setLogs = [
+      { exercises: null, set_number: 1 },
+      { exercises: { id: "ex-1", name: "Bench Press" }, set_number: 1 },
+    ];
+
+    const grouped: Map<string, any[]> = new Map();
+    for (const log of setLogs) {
+      const key = log.exercises?.id ?? "unknown";
+      if (!grouped.has(key)) grouped.set(key, []);
+      grouped.get(key)!.push(log);
+    }
+
+    expect(grouped.size).toBe(2);
+    expect(grouped.get("unknown")).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Added paginated API at `GET /api/sessions/history?page=1&limit=20` returning completed sessions with set_logs, ordered by `completed_at DESC`
- Added session history page at `/sessions/history` showing completed workouts in reverse chronological order with exercise names, sets/reps/weight breakdowns, effort badges, and pagination controls
- Added "History" link button on the main sessions page header

## Test plan
- [x] `pnpm tsc --noEmit` passes clean
- [x] `pnpm test` passes (533 tests across 40 files)
- [x] API tests cover: unauthenticated access (401), empty results, pagination params, limit clamping, error handling, enriched response with set_logs
- [x] Pagination logic tests cover offset calculation, total pages, clamping
- [x] Set log grouping tests cover normal and missing exercise data cases

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)