### PR TITLE
feat(14-2): Admin analytics dashboard

### DIFF
--- a/app/(admin)/analytics/analytics-dashboard.tsx
+++ b/app/(admin)/analytics/analytics-dashboard.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Users, Activity, TrendingUp, UserPlus, Calendar } from "lucide-react";
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recharts";
+
+interface AnalyticsData {
+  totalAthletes: number;
+  activeAthletes: number;
+  weeklyCompletionRate: number;
+  coachWorkload: Array<{ coachId: string; name: string; clientCount: number }>;
+  newSignups: number;
+  recentSessions: number;
+}
+
+export function AnalyticsDashboard({ data }: { data: AnalyticsData }) {
+  const statCards = [
+    {
+      title: "Total Athletes",
+      value: data.totalAthletes,
+      icon: Users,
+      description: "Registered users",
+    },
+    {
+      title: "Active Athletes",
+      value: data.activeAthletes,
+      icon: Activity,
+      description: "With active enrollment",
+    },
+    {
+      title: "Weekly Completion",
+      value: `${data.weeklyCompletionRate}%`,
+      icon: TrendingUp,
+      description: "Sessions completed (7d)",
+    },
+    {
+      title: "New Signups",
+      value: data.newSignups,
+      icon: UserPlus,
+      description: "Last 30 days",
+    },
+    {
+      title: "Recent Sessions",
+      value: data.recentSessions,
+      icon: Calendar,
+      description: "Logged in last 7 days",
+    },
+  ];
+
+  const chartData = data.coachWorkload.map((coach) => ({
+    name: coach.name.split(" ")[0] || coach.name,
+    clients: coach.clientCount,
+  }));
+
+  return (
+    <div>
+      {/* Stat Cards Grid */}
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))", gap: 16, marginBottom: 32 }}>
+        {statCards.map((stat) => (
+          <Card key={stat.title} style={{ backgroundColor: "#E8DECE", border: "1px solid #C8B99D" }}>
+            <CardHeader style={{ paddingBottom: 8 }}>
+              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                <CardTitle style={{ fontSize: 14, color: "#6B5A48", fontWeight: 500 }}>
+                  {stat.title}
+                </CardTitle>
+                <stat.icon style={{ width: 18, height: 18, color: "#988A78" }} />
+              </div>
+            </CardHeader>
+            <CardContent>
+              <p style={{ fontSize: 28, fontWeight: 700, color: "#C84B1A", marginBottom: 2 }}>
+                {stat.value}
+              </p>
+              <p style={{ fontSize: 12, color: "#988A78" }}>
+                {stat.description}
+              </p>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* Coach Workload Section */}
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 24 }}>
+        {/* Bar Chart */}
+        <Card style={{ backgroundColor: "#E8DECE", border: "1px solid #C8B99D" }}>
+          <CardHeader>
+            <CardTitle style={{ fontSize: 16, color: "#2C1A10" }}>Coach Workload</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {chartData.length > 0 ? (
+              <ResponsiveContainer width="100%" height={250}>
+                <BarChart data={chartData}>
+                  <XAxis
+                    dataKey="name"
+                    tick={{ fill: "#6B5A48", fontSize: 12 }}
+                    axisLine={{ stroke: "#C8B99D" }}
+                    tickLine={false}
+                  />
+                  <YAxis
+                    tick={{ fill: "#6B5A48", fontSize: 12 }}
+                    axisLine={{ stroke: "#C8B99D" }}
+                    tickLine={false}
+                    allowDecimals={false}
+                  />
+                  <Tooltip
+                    contentStyle={{
+                      backgroundColor: "#E8DECE",
+                      border: "1px solid #C8B99D",
+                      borderRadius: 8,
+                      color: "#2C1A10",
+                    }}
+                  />
+                  <Bar dataKey="clients" fill="#C84B1A" radius={[4, 4, 0, 0]} />
+                </BarChart>
+              </ResponsiveContainer>
+            ) : (
+              <p style={{ color: "#988A78", textAlign: "center", padding: 32 }}>
+                No coaches assigned yet
+              </p>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Coach Table */}
+        <Card style={{ backgroundColor: "#E8DECE", border: "1px solid #C8B99D" }}>
+          <CardHeader>
+            <CardTitle style={{ fontSize: 16, color: "#2C1A10" }}>Coach Details</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {data.coachWorkload.length > 0 ? (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead style={{ color: "#6B5A48" }}>Coach</TableHead>
+                    <TableHead style={{ color: "#6B5A48", textAlign: "right" }}>Clients</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {data.coachWorkload.map((coach) => (
+                    <TableRow key={coach.coachId}>
+                      <TableCell style={{ color: "#2C1A10", fontWeight: 500 }}>
+                        {coach.name}
+                      </TableCell>
+                      <TableCell style={{ color: "#C84B1A", fontWeight: 600, textAlign: "right" }}>
+                        {coach.clientCount}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            ) : (
+              <p style={{ color: "#988A78", textAlign: "center", padding: 32 }}>
+                No coaches assigned yet
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/app/(admin)/analytics/page.tsx
+++ b/app/(admin)/analytics/page.tsx
@@ -1,0 +1,119 @@
+import { createClient } from "@/lib/supabase/server";
+import { redirect } from "next/navigation";
+import { AnalyticsDashboard } from "./analytics-dashboard";
+
+interface AnalyticsData {
+  totalAthletes: number;
+  activeAthletes: number;
+  weeklyCompletionRate: number;
+  coachWorkload: Array<{ coachId: string; name: string; clientCount: number }>;
+  newSignups: number;
+  recentSessions: number;
+}
+
+async function getAnalyticsData(): Promise<AnalyticsData> {
+  const supabase = await createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    redirect("/login");
+  }
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("role")
+    .eq("id", user.id)
+    .single();
+
+  if (!profile || profile.role !== "admin") {
+    redirect("/dashboard");
+  }
+
+  // Total athletes
+  const { count: totalAthletes } = await supabase
+    .from("profiles")
+    .select("*", { count: "exact", head: true })
+    .eq("role", "user");
+
+  // Active athletes
+  const { count: activeAthletes } = await supabase
+    .from("user_enrollments")
+    .select("*", { count: "exact", head: true })
+    .eq("is_active", true);
+
+  // Weekly completion rate
+  const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+
+  const { count: totalRecentSessions } = await supabase
+    .from("session_logs")
+    .select("*", { count: "exact", head: true })
+    .gte("created_at", sevenDaysAgo);
+
+  const { count: completedRecentSessions } = await supabase
+    .from("session_logs")
+    .select("*", { count: "exact", head: true })
+    .gte("created_at", sevenDaysAgo)
+    .eq("is_complete", true);
+
+  const weeklyCompletionRate = totalRecentSessions && totalRecentSessions > 0
+    ? Math.round((completedRecentSessions ?? 0) / totalRecentSessions * 100)
+    : 0;
+
+  // Coach workload
+  const { data: coaches } = await supabase
+    .from("profiles")
+    .select("id, full_name, email")
+    .in("role", ["coach", "admin"]);
+
+  const coachWorkload: Array<{ coachId: string; name: string; clientCount: number }> = [];
+
+  if (coaches) {
+    for (const coach of coaches) {
+      const { count: clientCount } = await supabase
+        .from("profiles")
+        .select("*", { count: "exact", head: true })
+        .eq("coach_id", coach.id);
+
+      coachWorkload.push({
+        coachId: coach.id,
+        name: coach.full_name || coach.email,
+        clientCount: clientCount ?? 0,
+      });
+    }
+  }
+
+  // New signups (30 days)
+  const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+  const { count: newSignups } = await supabase
+    .from("profiles")
+    .select("*", { count: "exact", head: true })
+    .gte("created_at", thirtyDaysAgo);
+
+  return {
+    totalAthletes: totalAthletes ?? 0,
+    activeAthletes: activeAthletes ?? 0,
+    weeklyCompletionRate,
+    coachWorkload,
+    newSignups: newSignups ?? 0,
+    recentSessions: totalRecentSessions ?? 0,
+  };
+}
+
+export default async function AdminAnalyticsPage() {
+  const data = await getAnalyticsData();
+
+  return (
+    <div style={{ padding: 24 }}>
+      <div style={{ marginBottom: 24 }}>
+        <h1 style={{ fontSize: 24, fontWeight: 700, color: "#2C1A10", fontFamily: "var(--font-space-grotesk)", marginBottom: 4 }}>
+          Analytics
+        </h1>
+        <p style={{ color: "#6B5A48", fontSize: 14 }}>
+          Platform overview and coach workload metrics
+        </p>
+      </div>
+
+      <AnalyticsDashboard data={data} />
+    </div>
+  );
+}

--- a/app/api/admin/analytics/route.ts
+++ b/app/api/admin/analytics/route.ts
@@ -1,0 +1,99 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  try {
+    const supabase = await createClient();
+
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // Verify admin role
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("role")
+      .eq("id", user.id)
+      .single();
+
+    if (!profile || profile.role !== "admin") {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    // Total athletes (profiles where role = 'user')
+    const { count: totalAthletes } = await supabase
+      .from("profiles")
+      .select("*", { count: "exact", head: true })
+      .eq("role", "user");
+
+    // Active athletes (users with active enrollment)
+    const { count: activeAthletes } = await supabase
+      .from("user_enrollments")
+      .select("*", { count: "exact", head: true })
+      .eq("is_active", true);
+
+    // Weekly completion rate: % of session_logs completed in last 7 days
+    const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+
+    const { count: totalRecentSessions } = await supabase
+      .from("session_logs")
+      .select("*", { count: "exact", head: true })
+      .gte("created_at", sevenDaysAgo);
+
+    const { count: completedRecentSessions } = await supabase
+      .from("session_logs")
+      .select("*", { count: "exact", head: true })
+      .gte("created_at", sevenDaysAgo)
+      .eq("is_complete", true);
+
+    const weeklyCompletionRate = totalRecentSessions && totalRecentSessions > 0
+      ? Math.round((completedRecentSessions ?? 0) / totalRecentSessions * 100)
+      : 0;
+
+    // Coach workload: each coach and their client count
+    const { data: coaches } = await supabase
+      .from("profiles")
+      .select("id, full_name, email")
+      .in("role", ["coach", "admin"]);
+
+    const coachWorkload: Array<{ coachId: string; name: string; clientCount: number }> = [];
+
+    if (coaches) {
+      for (const coach of coaches) {
+        const { count: clientCount } = await supabase
+          .from("profiles")
+          .select("*", { count: "exact", head: true })
+          .eq("coach_id", coach.id);
+
+        coachWorkload.push({
+          coachId: coach.id,
+          name: coach.full_name || coach.email,
+          clientCount: clientCount ?? 0,
+        });
+      }
+    }
+
+    // New signups in last 30 days
+    const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+    const { count: newSignups } = await supabase
+      .from("profiles")
+      .select("*", { count: "exact", head: true })
+      .gte("created_at", thirtyDaysAgo);
+
+    // Recent sessions (session_logs created in last 7 days)
+    const recentSessions = totalRecentSessions ?? 0;
+
+    return NextResponse.json({
+      totalAthletes: totalAthletes ?? 0,
+      activeAthletes: activeAthletes ?? 0,
+      weeklyCompletionRate,
+      coachWorkload,
+      newSignups: newSignups ?? 0,
+      recentSessions,
+    });
+  } catch (error) {
+    console.error("Error in GET /api/admin/analytics:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
   BookOpen,
   UserCog,
   ClipboardList,
+  BarChart3,
 } from "lucide-react";
 import { getNavItems, type NavItem } from "@/lib/profile";
 import type { UserRole } from "@/lib/types";
@@ -24,6 +25,7 @@ const ICON_MAP: Record<string, React.ElementType> = {
   BookOpen,
   UserCog,
   ClipboardList,
+  BarChart3,
 };
 
 interface SidebarProps {

--- a/lib/profile.ts
+++ b/lib/profile.ts
@@ -30,6 +30,7 @@ export function getNavItems(role: UserRole, hasCoach: boolean): NavItem[] {
   const adminItems: NavItem[] = [
     { label: "Users", href: "/admin/users", icon: "UserCog" },
     { label: "Programs", href: "/admin/programs", icon: "ClipboardList" },
+    { label: "Analytics", href: "/admin/analytics", icon: "BarChart3" },
   ];
 
   if (role === "admin") {

--- a/lib/roadmap-data.ts
+++ b/lib/roadmap-data.ts
@@ -855,7 +855,7 @@ export const ROADMAP: RoadmapBatch[] = [
           "New admin page: total active athletes, weekly completion rate,",
           "coach workload, new signups. Backend aggregation endpoint.",
         ].join("\n"),
-        status: "not-started",
+        status: "in-progress",
         tests: true,
         branch: "feat/admin-analytics",
         issue: 112,

--- a/tests/admin-analytics.test.ts
+++ b/tests/admin-analytics.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { GET } from "@/app/api/admin/analytics/route";
+
+const mockSupabase = {
+  auth: { getUser: vi.fn() },
+  from: vi.fn(),
+  select: vi.fn(),
+  eq: vi.fn(),
+  in: vi.fn(),
+  gte: vi.fn(),
+  single: vi.fn(),
+};
+
+// Build a chainable mock that tracks calls
+function createChainableMock() {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {
+    select: vi.fn(),
+    eq: vi.fn(),
+    in: vi.fn(),
+    gte: vi.fn(),
+    single: vi.fn(),
+    order: vi.fn(),
+  };
+
+  // Each method returns the chain itself by default
+  Object.values(chain).forEach((fn) => fn.mockReturnValue(chain));
+
+  return chain;
+}
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(),
+}));
+
+import { createClient } from "@/lib/supabase/server";
+const mockedCreateClient = vi.mocked(createClient);
+
+describe("Admin Analytics API", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return 401 if not authenticated", async () => {
+    const chain = createChainableMock();
+    const client = {
+      auth: { getUser: vi.fn().mockResolvedValue({ data: { user: null } }) },
+      from: vi.fn().mockReturnValue(chain),
+    };
+    mockedCreateClient.mockResolvedValue(client as any);
+
+    const response = await GET();
+    expect(response.status).toBe(401);
+
+    const data = await response.json();
+    expect(data.error).toBe("Unauthorized");
+  });
+
+  it("should return 403 if not admin role", async () => {
+    const chain = createChainableMock();
+    chain.single.mockResolvedValue({ data: { role: "user" }, error: null });
+
+    const client = {
+      auth: { getUser: vi.fn().mockResolvedValue({ data: { user: { id: "u1" } } }) },
+      from: vi.fn().mockReturnValue(chain),
+    };
+    mockedCreateClient.mockResolvedValue(client as any);
+
+    const response = await GET();
+    expect(response.status).toBe(403);
+
+    const data = await response.json();
+    expect(data.error).toBe("Forbidden");
+  });
+
+  it("should return 200 with expected shape for admin", async () => {
+    // Track which table is being queried
+    let callIndex = 0;
+    const profileAdminChain = createChainableMock();
+    profileAdminChain.single.mockResolvedValue({ data: { role: "admin" }, error: null });
+
+    const countChain = (count: number) => {
+      const c = createChainableMock();
+      // Override select to resolve with count
+      c.select.mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ count, error: null }),
+        gte: vi.fn().mockReturnValue({
+          eq: vi.fn().mockResolvedValue({ count, error: null }),
+        }),
+      });
+      // Direct resolves for methods that end the chain
+      c.eq.mockResolvedValue({ count, error: null });
+      c.gte.mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ count, error: null }),
+      });
+      return c;
+    };
+
+    // We need a more precise mock that handles the various query paths
+    const fromMock = vi.fn();
+
+    // Simulate: profiles(role check) -> profiles(totalAthletes) -> user_enrollments -> session_logs -> session_logs -> profiles(coaches) -> profiles(client count per coach) -> profiles(newSignups)
+    const roleCheckChain = createChainableMock();
+    roleCheckChain.single.mockResolvedValue({ data: { role: "admin" }, error: null });
+
+    // For count queries, we need select({count:"exact", head:true}) to return a chain ending in count
+    const makeCountResolve = (count: number) => {
+      const obj: any = {
+        eq: vi.fn().mockResolvedValue({ count, error: null }),
+        gte: vi.fn().mockReturnValue({
+          eq: vi.fn().mockResolvedValue({ count, error: null }),
+        }),
+        in: vi.fn().mockResolvedValue({ data: [{ id: "coach-1", full_name: "Coach A", email: "coach@test.com" }], error: null }),
+      };
+      // gte without further eq
+      obj.gte.mockResolvedValue({ count, error: null });
+      return obj;
+    };
+
+    // Build a mock client where .from() returns different chains depending on call order
+    let fromCallCount = 0;
+    const mockClient = {
+      auth: { getUser: vi.fn().mockResolvedValue({ data: { user: { id: "admin-1" } } }) },
+      from: vi.fn().mockImplementation((table: string) => {
+        fromCallCount++;
+        if (fromCallCount === 1) {
+          // First from("profiles") -> role check
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                single: vi.fn().mockResolvedValue({ data: { role: "admin" }, error: null }),
+              }),
+            }),
+          };
+        }
+        if (fromCallCount === 2) {
+          // profiles count (totalAthletes)
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockResolvedValue({ count: 10, error: null }),
+            }),
+          };
+        }
+        if (fromCallCount === 3) {
+          // user_enrollments count (activeAthletes)
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockResolvedValue({ count: 7, error: null }),
+            }),
+          };
+        }
+        if (fromCallCount === 4) {
+          // session_logs count (totalRecentSessions)
+          return {
+            select: vi.fn().mockReturnValue({
+              gte: vi.fn().mockResolvedValue({ count: 20, error: null }),
+            }),
+          };
+        }
+        if (fromCallCount === 5) {
+          // session_logs count (completedRecentSessions)
+          return {
+            select: vi.fn().mockReturnValue({
+              gte: vi.fn().mockReturnValue({
+                eq: vi.fn().mockResolvedValue({ count: 15, error: null }),
+              }),
+            }),
+          };
+        }
+        if (fromCallCount === 6) {
+          // profiles (coaches list)
+          return {
+            select: vi.fn().mockReturnValue({
+              in: vi.fn().mockResolvedValue({
+                data: [
+                  { id: "coach-1", full_name: "Coach Alpha", email: "coach@test.com" },
+                ],
+                error: null,
+              }),
+            }),
+          };
+        }
+        if (fromCallCount === 7) {
+          // profiles count per coach (clientCount)
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockResolvedValue({ count: 3, error: null }),
+            }),
+          };
+        }
+        if (fromCallCount === 8) {
+          // profiles count (newSignups)
+          return {
+            select: vi.fn().mockReturnValue({
+              gte: vi.fn().mockResolvedValue({ count: 5, error: null }),
+            }),
+          };
+        }
+        // fallback
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ count: 0, error: null }),
+            gte: vi.fn().mockResolvedValue({ count: 0, error: null }),
+            in: vi.fn().mockResolvedValue({ data: [], error: null }),
+          }),
+        };
+      }),
+    };
+
+    mockedCreateClient.mockResolvedValue(mockClient as any);
+
+    const response = await GET();
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data).toHaveProperty("totalAthletes");
+    expect(data).toHaveProperty("activeAthletes");
+    expect(data).toHaveProperty("weeklyCompletionRate");
+    expect(data).toHaveProperty("coachWorkload");
+    expect(data).toHaveProperty("newSignups");
+    expect(data).toHaveProperty("recentSessions");
+
+    expect(typeof data.totalAthletes).toBe("number");
+    expect(typeof data.activeAthletes).toBe("number");
+    expect(typeof data.weeklyCompletionRate).toBe("number");
+    expect(Array.isArray(data.coachWorkload)).toBe(true);
+    expect(typeof data.newSignups).toBe("number");
+    expect(typeof data.recentSessions).toBe("number");
+
+    // Verify values from our mock
+    expect(data.totalAthletes).toBe(10);
+    expect(data.activeAthletes).toBe(7);
+    expect(data.weeklyCompletionRate).toBe(75); // 15/20 * 100
+    expect(data.coachWorkload).toHaveLength(1);
+    expect(data.coachWorkload[0].name).toBe("Coach Alpha");
+    expect(data.coachWorkload[0].clientCount).toBe(3);
+    expect(data.newSignups).toBe(5);
+    expect(data.recentSessions).toBe(20);
+  });
+});


### PR DESCRIPTION
## Summary
- New admin analytics API endpoint (`/api/admin/analytics`) returning total athletes, active athletes, weekly completion rate, coach workload, new signups, and recent sessions
- New admin analytics page (`/admin/analytics`) with stat cards grid, coach workload bar chart (recharts), and coach details table
- Added "Analytics" link to sidebar navigation for admin users

Closes #112

## Test plan
- [ ] Verify 401 response when not authenticated
- [ ] Verify 403 response when authenticated as non-admin
- [ ] Verify 200 response with correct data shape for admin users
- [ ] Confirm analytics page renders stat cards with design tokens
- [ ] Confirm coach workload bar chart displays correctly
- [ ] Confirm sidebar shows Analytics link for admin role only

🤖 Generated with [Claude Code](https://claude.com/claude-code)