### PR TITLE
fix(9-3): complete apiFetchJson migration

### DIFF
--- a/app/(admin)/overrides/page.tsx
+++ b/app/(admin)/overrides/page.tsx
@@ -8,6 +8,7 @@ import { Select } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
 import { toast } from "sonner";
 import { Search, Users, Settings } from "lucide-react";
+import { apiFetchJson } from "@/lib/api-helpers";
 import { UserOverrideEditor } from "./user-override-editor";
 
 interface ProfileWithCoach extends Profile {
@@ -25,11 +26,7 @@ export default function OverridesPage() {
 
   const fetchUsers = async () => {
     try {
-      const response = await fetch("/api/admin/users");
-      if (!response.ok) {
-        throw new Error("Failed to fetch users");
-      }
-      const data = await response.json();
+      const data = await apiFetchJson<ProfileWithCoach[]>("/api/admin/users");
       // Only include users with user role for overrides
       setUsers(data.filter((user: ProfileWithCoach) => user.role === "user"));
     } catch (error) {

--- a/app/(admin)/overrides/user-override-editor.tsx
+++ b/app/(admin)/overrides/user-override-editor.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/components/ui/table";
 import { toast } from "sonner";
 import { Settings, Save, X, Edit, Trash2, Plus } from "lucide-react";
+import { apiFetchJson } from "@/lib/api-helpers";
 import { getDefaultWeight } from "@/lib/utils";
 
 interface UserProgramData {
@@ -72,11 +73,7 @@ export function UserOverrideEditor({ userId }: { userId: string }) {
   const fetchUserData = async () => {
     try {
       setLoading(true);
-      const response = await fetch(`/api/admin/overrides/users?user_id=${userId}`);
-      if (!response.ok) {
-        throw new Error("Failed to fetch user data");
-      }
-      const data = await response.json();
+      const data = await apiFetchJson<UserProgramData>(`/api/admin/overrides/users?user_id=${userId}`);
       setUserData(data);
     } catch (error) {
       console.error("Error fetching user data:", error);
@@ -126,15 +123,11 @@ export function UserOverrideEditor({ userId }: { userId: string }) {
         notes: editForm.notes,
       };
 
-      const response = await fetch("/api/admin/overrides", {
+      await apiFetchJson("/api/admin/overrides", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),
       });
-
-      if (!response.ok) {
-        throw new Error("Failed to save override");
-      }
 
       await fetchUserData();
       handleEditCancel();
@@ -151,15 +144,11 @@ export function UserOverrideEditor({ userId }: { userId: string }) {
     }
 
     try {
-      const response = await fetch("/api/admin/overrides", {
+      await apiFetchJson("/api/admin/overrides", {
         method: "DELETE",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ id: overrideId }),
       });
-
-      if (!response.ok) {
-        throw new Error("Failed to delete override");
-      }
 
       await fetchUserData();
       toast.success("Override removed successfully");

--- a/app/(admin)/programs/[id]/page.tsx
+++ b/app/(admin)/programs/[id]/page.tsx
@@ -18,6 +18,7 @@ import { toast } from "sonner";
 import { ArrowLeft, Save, Edit, X, Check, AlertTriangle } from "lucide-react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
+import { apiFetchJson, ApiError } from "@/lib/api-helpers";
 
 interface ProgramWithPhases extends Program {
   phases?: Phase[];
@@ -56,15 +57,7 @@ export default function ProgramEditorPage() {
 
   const fetchProgram = async () => {
     try {
-      const response = await fetch(`/api/admin/programs/${programId}`);
-      if (!response.ok) {
-        if (response.status === 404) {
-          toast.error("Program not found");
-          return;
-        }
-        throw new Error("Failed to fetch program");
-      }
-      const data = await response.json();
+      const data = await apiFetchJson<ProgramWithPhases>(`/api/admin/programs/${programId}`);
       setProgram(data);
       setProgramForm({
         name: data.name || "",
@@ -74,7 +67,11 @@ export default function ProgramEditorPage() {
       });
     } catch (error) {
       console.error("Error fetching program:", error);
-      toast.error("Failed to load program");
+      if (error instanceof ApiError && error.status === 404) {
+        toast.error("Program not found");
+      } else {
+        toast.error("Failed to load program");
+      }
     } finally {
       setLoading(false);
     }
@@ -83,15 +80,11 @@ export default function ProgramEditorPage() {
   const handleSaveProgram = async () => {
     setSaving(true);
     try {
-      const response = await fetch("/api/admin/programs", {
+      await apiFetchJson("/api/admin/programs", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ id: programId, ...programForm }),
       });
-
-      if (!response.ok) {
-        throw new Error("Failed to update program");
-      }
 
       await fetchProgram();
       setEditingProgram(false);
@@ -118,15 +111,11 @@ export default function ProgramEditorPage() {
   const handleSavePhase = async (phaseId: string) => {
     setSaving(true);
     try {
-      const response = await fetch(`/api/admin/programs/${programId}/phases`, {
+      await apiFetchJson(`/api/admin/programs/${programId}/phases`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ phaseId, ...phaseForm }),
       });
-
-      if (!response.ok) {
-        throw new Error("Failed to update phase");
-      }
 
       await fetchProgram();
       setEditingPhase(null);

--- a/app/(admin)/programs/[id]/session-editor/SessionEditor.tsx
+++ b/app/(admin)/programs/[id]/session-editor/SessionEditor.tsx
@@ -10,6 +10,7 @@ import { Label } from '@/components/ui/label';
 import { Plus, Save, ArrowLeft } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
+import { apiFetchJson } from '@/lib/api-helpers';
 import type { WorkoutTemplate, TemplateExercise, Exercise } from '@/lib/types';
 import { ExerciseItem } from './ExerciseItem';
 import { ExerciseLibraryDialog } from './ExerciseLibraryDialog';
@@ -53,7 +54,7 @@ export function SessionEditor({ template, templateExercises, allExercises, progr
     
     try {
       // Update in database
-      const response = await fetch(`/api/admin/programs/${programId}/session-editor/reorder`, {
+      await apiFetchJson(`/api/admin/programs/${programId}/session-editor/reorder`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -61,11 +62,7 @@ export function SessionEditor({ template, templateExercises, allExercises, progr
           exercises: newExercises.map(ex => ({ id: ex.id, order_index: ex.order_index }))
         })
       });
-      
-      if (!response.ok) {
-        throw new Error('Failed to reorder exercises');
-      }
-      
+
       setExercises(newExercises);
       toast.success('Exercise order updated');
     } catch (error) {
@@ -78,22 +75,19 @@ export function SessionEditor({ template, templateExercises, allExercises, progr
 
   const handleAddExercise = async (exerciseId: string) => {
     try {
-      const response = await fetch(`/api/admin/programs/${programId}/session-editor/exercises`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          sessionId: template.id,
-          exerciseId,
-          orderIndex: exercises.length
-        })
-      });
-      
-      if (!response.ok) {
-        throw new Error('Failed to add exercise');
-      }
-      
-      const { templateExercise } = await response.json();
-      
+      const { templateExercise } = await apiFetchJson<{ templateExercise: TemplateExercise & { exercise: Exercise } }>(
+        `/api/admin/programs/${programId}/session-editor/exercises`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            sessionId: template.id,
+            exerciseId,
+            orderIndex: exercises.length
+          })
+        }
+      );
+
       setExercises(prev => [...prev, templateExercise]);
       toast.success('Exercise added to session');
       setIsLibraryOpen(false);
@@ -105,14 +99,10 @@ export function SessionEditor({ template, templateExercises, allExercises, progr
 
   const handleRemoveExercise = async (exerciseId: string) => {
     try {
-      const response = await fetch(`/api/admin/programs/${programId}/session-editor/exercises/${exerciseId}`, {
+      await apiFetchJson(`/api/admin/programs/${programId}/session-editor/exercises/${exerciseId}`, {
         method: 'DELETE'
       });
-      
-      if (!response.ok) {
-        throw new Error('Failed to remove exercise');
-      }
-      
+
       setExercises(prev => prev.filter(ex => ex.id !== exerciseId));
       toast.success('Exercise removed from session');
     } catch (error) {
@@ -123,18 +113,15 @@ export function SessionEditor({ template, templateExercises, allExercises, progr
 
   const handleUpdateExercise = async (exerciseId: string, updates: Partial<TemplateExercise>) => {
     try {
-      const response = await fetch(`/api/admin/programs/${programId}/session-editor/exercises/${exerciseId}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(updates)
-      });
-      
-      if (!response.ok) {
-        throw new Error('Failed to update exercise');
-      }
-      
-      const { templateExercise } = await response.json();
-      
+      const { templateExercise } = await apiFetchJson<{ templateExercise: TemplateExercise & { exercise: Exercise } }>(
+        `/api/admin/programs/${programId}/session-editor/exercises/${exerciseId}`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(updates)
+        }
+      );
+
       setExercises(prev => prev.map(ex => ex.id === exerciseId ? { ...ex, ...templateExercise } : ex));
       toast.success('Exercise updated');
     } catch (error) {

--- a/app/(admin)/programs/page.tsx
+++ b/app/(admin)/programs/page.tsx
@@ -16,6 +16,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { toast } from "sonner";
 import { Edit, Settings, Dumbbell } from "lucide-react";
 import Link from "next/link";
+import { apiFetchJson } from "@/lib/api-helpers";
 
 interface ProgramWithPhases extends Program {
   phases?: Phase[];
@@ -31,11 +32,7 @@ export default function AdminProgramsPage() {
 
   const fetchPrograms = async () => {
     try {
-      const response = await fetch("/api/admin/programs");
-      if (!response.ok) {
-        throw new Error("Failed to fetch programs");
-      }
-      const data = await response.json();
+      const data = await apiFetchJson<ProgramWithPhases[]>("/api/admin/programs");
       setPrograms(data);
     } catch (error) {
       console.error("Error fetching programs:", error);

--- a/app/(admin)/users/page.tsx
+++ b/app/(admin)/users/page.tsx
@@ -40,11 +40,7 @@ export default function AdminUsersPage() {
 
   const fetchUsers = async () => {
     try {
-      const response = await fetch("/api/admin/users");
-      if (!response.ok) {
-        throw new Error("Failed to fetch users");
-      }
-      const data = await response.json();
+      const data = await apiFetchJson<ProfileWithCoach[]>("/api/admin/users");
       setUsers(data);
       setCoaches(data.filter((user: ProfileWithCoach) => user.role === "coach" || user.role === "admin"));
     } catch (error) {
@@ -100,15 +96,11 @@ export default function AdminUsersPage() {
 
   const handleEditSave = async (userId: string) => {
     try {
-      const response = await fetch("/api/admin/users", {
+      await apiFetchJson("/api/admin/users", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ id: userId, ...editForm }),
       });
-
-      if (!response.ok) {
-        throw new Error("Failed to update user");
-      }
 
       await fetchUsers();
       setEditingUser(null);
@@ -126,15 +118,11 @@ export default function AdminUsersPage() {
     }
 
     try {
-      const response = await fetch("/api/admin/users", {
+      await apiFetchJson("/api/admin/users", {
         method: "DELETE",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ id: userId }),
       });
-
-      if (!response.ok) {
-        throw new Error("Failed to deactivate user");
-      }
 
       await fetchUsers();
       toast.success("User deactivated successfully");

--- a/app/(app)/billing/page.tsx
+++ b/app/(app)/billing/page.tsx
@@ -5,6 +5,7 @@ import { createClient } from "@/lib/supabase/client";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { CreditCard, CheckCircle, XCircle, ExternalLink } from "lucide-react";
 import { toast } from "sonner";
+import { apiFetchJson } from "@/lib/api-helpers";
 
 interface PlanTier {
   name: string;
@@ -89,18 +90,11 @@ export default function BillingPage() {
   async function handleCheckout(priceId: string) {
     setCheckoutLoading(priceId);
     try {
-      const res = await fetch("/api/billing/checkout", {
+      const { url } = await apiFetchJson<{ url: string }>("/api/billing/checkout", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ priceId }),
       });
-
-      if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.error ?? "Failed to create checkout session");
-      }
-
-      const { url } = await res.json();
       if (url) {
         window.location.href = url;
       }
@@ -114,17 +108,10 @@ export default function BillingPage() {
   async function handlePortal() {
     setPortalLoading(true);
     try {
-      const res = await fetch("/api/billing/portal", {
+      const { url } = await apiFetchJson<{ url: string }>("/api/billing/portal", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
       });
-
-      if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.error ?? "Failed to open billing portal");
-      }
-
-      const { url } = await res.json();
       if (url) {
         window.location.href = url;
       }

--- a/app/(app)/progress/charts/ChartContainer.tsx
+++ b/app/(app)/progress/charts/ChartContainer.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { toast } from "sonner";
+import { apiFetchJson } from "@/lib/api-helpers";
 import LiftChart from "@/components/LiftChart";
 import ExerciseSelector from "./ExerciseSelector";
 
@@ -37,18 +39,14 @@ export default function ChartContainer({ userId }: ChartContainerProps) {
       setError(null);
       
       try {
-        const response = await fetch(
+        const data = await apiFetchJson<{ data: ChartDataPoint[] }>(
           `/api/progress/charts?exerciseId=${selectedExerciseId}&userId=${userId}`
         );
-        
-        if (!response.ok) {
-          throw new Error('Failed to fetch chart data');
-        }
-        
-        const data = await response.json();
         setChartData(data.data || []);
       } catch (err) {
-        setError(err instanceof Error ? err.message : 'Unknown error');
+        const message = err instanceof Error ? err.message : 'Unknown error';
+        setError(message);
+        toast.error(message);
         setChartData([]);
       } finally {
         setLoading(false);

--- a/app/(app)/progress/charts/ExerciseSelector.tsx
+++ b/app/(app)/progress/charts/ExerciseSelector.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { toast } from "sonner";
+import { apiFetchJson } from "@/lib/api-helpers";
 
 interface Exercise {
   id: string;
@@ -26,14 +28,12 @@ export default function ExerciseSelector({
   useEffect(() => {
     async function fetchExercises() {
       try {
-        const response = await fetch(`/api/progress/exercises?userId=${userId}`);
-        if (!response.ok) {
-          throw new Error('Failed to fetch exercises');
-        }
-        const data = await response.json();
+        const data = await apiFetchJson<{ exercises: Exercise[] }>(`/api/progress/exercises?userId=${userId}`);
         setExercises(data.exercises || []);
       } catch (err) {
-        setError(err instanceof Error ? err.message : 'Unknown error');
+        const message = err instanceof Error ? err.message : 'Unknown error';
+        setError(message);
+        toast.error(message);
       } finally {
         setLoading(false);
       }

--- a/app/(coach)/clients/[id]/FormAssessmentPanel.tsx
+++ b/app/(coach)/clients/[id]/FormAssessmentPanel.tsx
@@ -8,6 +8,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { CoachFormAssessment, Exercise, FormAssessmentStatus } from "@/lib/types";
 import { Loader2, CheckCircle, AlertTriangle, HelpCircle } from "lucide-react";
 import { toast } from "sonner";
+import { apiFetchJson } from "@/lib/api-helpers";
 
 interface FormAssessmentPanelProps {
   clientId: string;
@@ -47,13 +48,11 @@ export default function FormAssessmentPanel({ clientId }: FormAssessmentPanelPro
 
   const fetchExercisesWithAssessments = useCallback(async () => {
     try {
-      const res = await fetch(`/api/coach/form-assessment?clientId=${clientId}`);
-      if (!res.ok) {
-        throw new Error('Failed to fetch form assessments');
-      }
-      const data = await res.json();
+      const data = await apiFetchJson<{ exercises: ExerciseWithAssessment[] }>(
+        `/api/coach/form-assessment?clientId=${clientId}`
+      );
       setExercises(data.exercises);
-      
+
       // Initialize local notes state
       const notesMap: Record<string, string> = {};
       data.exercises.forEach((ex: ExerciseWithAssessment) => {
@@ -77,27 +76,24 @@ export default function FormAssessmentPanel({ clientId }: FormAssessmentPanelPro
   const handleStatusChange = async (exerciseId: string, status: FormAssessmentStatus) => {
     setSaving(exerciseId);
     try {
-      const res = await fetch('/api/coach/form-assessment', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          clientId,
-          exerciseId,
-          status,
-          privateNotes: localNotes[exerciseId] || null,
-        }),
-      });
+      const updatedAssessment = await apiFetchJson<{ assessment: CoachFormAssessment }>(
+        '/api/coach/form-assessment',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            clientId,
+            exerciseId,
+            status,
+            privateNotes: localNotes[exerciseId] || null,
+          }),
+        }
+      );
 
-      if (!res.ok) {
-        throw new Error('Failed to save assessment');
-      }
-
-      const updatedAssessment = await res.json();
-      
       // Update local state
-      setExercises(prev => 
-        prev.map(ex => 
-          ex.id === exerciseId 
+      setExercises(prev =>
+        prev.map(ex =>
+          ex.id === exerciseId
             ? { ...ex, assessment: updatedAssessment.assessment }
             : ex
         )
@@ -125,7 +121,7 @@ export default function FormAssessmentPanel({ clientId }: FormAssessmentPanelPro
 
     setSaving(exerciseId);
     try {
-      const res = await fetch('/api/coach/form-assessment', {
+      await apiFetchJson('/api/coach/form-assessment', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -135,10 +131,6 @@ export default function FormAssessmentPanel({ clientId }: FormAssessmentPanelPro
           privateNotes: localNotes[exerciseId] || null,
         }),
       });
-
-      if (!res.ok) {
-        throw new Error('Failed to save notes');
-      }
 
       await fetchExercisesWithAssessments(); // Refresh to get updated timestamps
       toast.success('Notes saved');

--- a/app/(coach)/playbook/page.tsx
+++ b/app/(coach)/playbook/page.tsx
@@ -9,6 +9,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
+import { apiFetchJson } from "@/lib/api-helpers";
 import type { PlaybookEntry } from "@/lib/types";
 
 interface EntryFormData {
@@ -34,11 +35,7 @@ export default function PlaybookPage() {
 
   const fetchEntries = useCallback(async () => {
     try {
-      const res = await fetch("/api/coach/playbook");
-      if (!res.ok) {
-        throw new Error("Failed to fetch playbook entries");
-      }
-      const data = await res.json();
+      const data = await apiFetchJson<PlaybookEntry[]>("/api/coach/playbook");
       setEntries(data);
     } catch {
       toast.error("Failed to load playbook entries");
@@ -94,24 +91,18 @@ export default function PlaybookPage() {
         category: formData.category.trim() || null,
       };
 
-      let res: Response;
       if (editingId) {
-        res = await fetch("/api/coach/playbook", {
+        await apiFetchJson("/api/coach/playbook", {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ id: editingId, ...payload }),
         });
       } else {
-        res = await fetch("/api/coach/playbook", {
+        await apiFetchJson("/api/coach/playbook", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(payload),
         });
-      }
-
-      if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.error || "Failed to save");
       }
 
       toast.success(editingId ? "Entry updated" : "Entry created");
@@ -127,15 +118,7 @@ export default function PlaybookPage() {
   const handleDelete = async (id: string) => {
     setDeletingId(id);
     try {
-      const res = await fetch(`/api/coach/playbook?id=${id}`, {
-        method: "DELETE",
-      });
-
-      if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.error || "Failed to delete");
-      }
-
+      await apiFetchJson(`/api/coach/playbook?id=${id}`, { method: "DELETE" });
       toast.success("Entry deleted");
       fetchEntries();
     } catch (err) {

--- a/components/SendNoteDialog.tsx
+++ b/components/SendNoteDialog.tsx
@@ -14,6 +14,8 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { MessageSquare, Send } from "lucide-react";
+import { toast } from "sonner";
+import { apiFetchJson } from "@/lib/api-helpers";
 
 interface SendNoteDialogProps {
   clientId: string;
@@ -41,7 +43,7 @@ export default function SendNoteDialog({
     setError("");
 
     try {
-      const response = await fetch("/api/coach/notes", {
+      await apiFetchJson("/api/coach/notes", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -52,16 +54,13 @@ export default function SendNoteDialog({
         }),
       });
 
-      if (response.ok) {
-        setMessage("");
-        setIsOpen(false);
-        onNoteSent?.();
-      } else {
-        const errorData = await response.json();
-        setError(errorData.error || "Failed to send note");
-      }
+      setMessage("");
+      setIsOpen(false);
+      onNoteSent?.();
     } catch (err) {
-      setError("Network error - please try again");
+      const message = err instanceof Error ? err.message : "Failed to send note";
+      setError(message);
+      toast.error(message);
     } finally {
       setIsLoading(false);
     }

--- a/components/quick-log/QuickLogModal.tsx
+++ b/components/quick-log/QuickLogModal.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Dumbbell } from "lucide-react";
 import { toast } from "sonner";
+import { apiFetchJson } from "@/lib/api-helpers";
 import {
   getPresetExercises,
   type MuscleGroupKey,
@@ -36,7 +37,7 @@ export default function QuickLogModal({ open, onClose }: { open: boolean; onClos
     setSaving(true);
     try {
       const start = performance.now();
-      const res = await fetch("/api/quick-log", {
+      await apiFetchJson("/api/quick-log", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -44,7 +45,6 @@ export default function QuickLogModal({ open, onClose }: { open: boolean; onClos
           exercises: exercises.map(ex => ({ name: ex.name, muscleGroup: ex.muscleGroup, sets: ex.sets })),
         }),
       });
-      if (!res.ok) throw new Error(await res.text());
       const elapsed = performance.now() - start;
       if (elapsed < 500) await new Promise(r => setTimeout(r, 500 - elapsed));
       setSaved(true);

--- a/lib/roadmap-data.ts
+++ b/lib/roadmap-data.ts
@@ -515,7 +515,7 @@ export const ROADMAP: RoadmapBatch[] = [
           "Migrate all callers that currently ignore error responses.",
           "Each migrated caller should catch and show toast.error().",
         ].join("\n"),
-        status: "in-progress",
+        status: "done",
         tests: true,
         branch: "fix/api-error-handling",
         issue: 99,


### PR DESCRIPTION
## Summary
- Migrates 13 components from raw `fetch()` to `apiFetchJson` with typed error handling
- All API failures now surface via `toast.error()` instead of being silently swallowed
- Net reduction of ~100 lines — eliminates duplicated response.ok checks and manual JSON parsing
- Marks roadmap item 9-3 as done

## Files migrated
ChartContainer, ExerciseSelector, billing/page, playbook/page, FormAssessmentPanel, overrides/page, user-override-editor, programs/page, programs/[id]/page, SessionEditor, users/page, SendNoteDialog, QuickLogModal

## Test plan
- [x] `pnpm tsc --noEmit` passes
- [x] No raw `fetch()` remains in user-facing components (only `opengraph-image.tsx` server-side and `monitor/` internal tooling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)