### PR TITLE
fix(10-3): mark RLS INSERT policy as done

### DIFF
--- a/lib/roadmap-data.ts
+++ b/lib/roadmap-data.ts
@@ -577,7 +577,7 @@ export const ROADMAP: RoadmapBatch[] = [
           "Missing explicit INSERT WITH CHECK policy on coach_form_assessments.",
           "Add migration: CREATE POLICY form_assessments_coach_insert ON coach_form_assessments FOR INSERT WITH CHECK (coach_id = auth.uid());",
         ].join("\n"),
-        status: "in-progress",
+        status: "done",
         tests: false,
         branch: "fix/form-assessment-rls",
         issue: 120,


### PR DESCRIPTION
## Summary
- Migration `005_form_assessment_rls.sql` was already merged but roadmap status was never updated
- Marks roadmap item 10-3 (`coach_form_assessments` INSERT policy) as done
- With this + PR #148, all 36 Roadmap V2 items are complete

## Test plan
- [x] Data-only change — updates `lib/roadmap-data.ts` status field

🤖 Generated with [Claude Code](https://claude.com/claude-code)