### PR TITLE
fix: exclude stale worktrees from vitest (180 false failures)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ Thumbs.db
 # Replit
 .cache/
 .local/
+
+# Claude Code agent worktrees
+.claude/worktrees/

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     setupFiles: ["./tests/setup.ts"],
-    exclude: ["**/node_modules/**", "**/.migration-backup/**"],
+    exclude: ["**/node_modules/**", "**/.migration-backup/**", "**/.claude/**"],
     coverage: {
       provider: "v8",
       include: ["lib/**/*.ts"],


### PR DESCRIPTION
## Summary
- All 180 test failures were caused by stale `.claude/worktrees/` directories containing duplicate test files from past agent runs
- Adds `**/.claude/**` to vitest exclude list
- Adds `.claude/worktrees/` to `.gitignore` to prevent future pollution
- **Result: 46 test files, 585 tests, all passing**

## Test plan
- [x] `pnpm test` — 46 passed, 0 failed (was 30 failed / 214 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)