### PR TITLE
feat: add dashboard widgets — volume chart, upcoming sessions, recent PRs

### DIFF
--- a/app/(app)/dashboard/RecentPRs.tsx
+++ b/app/(app)/dashboard/RecentPRs.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { Trophy } from "lucide-react";
+
+export interface PREntry {
+  exerciseName: string;
+  weight: number;
+  achievedAt: string;
+}
+
+interface RecentPRsProps {
+  prs: PREntry[];
+}
+
+export default function RecentPRs({ prs }: RecentPRsProps) {
+  if (prs.length === 0) {
+    return (
+      <div className="flex items-center justify-center text-content-muted text-sm py-6">
+        No personal records yet — keep lifting!
+      </div>
+    );
+  }
+
+  return (
+    <ul className="space-y-3">
+      {prs.map((pr) => (
+        <li key={pr.exerciseName} className="flex items-center gap-3">
+          <div className="flex-shrink-0 h-8 w-8 rounded-full bg-warning/15 flex items-center justify-center">
+            <Trophy className="h-4 w-4 text-warning" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="text-sm font-medium text-content-primary truncate">
+              {pr.exerciseName}
+            </div>
+            <div className="text-xs text-content-muted">
+              {new Date(pr.achievedAt).toLocaleDateString("en-US", {
+                month: "short",
+                day: "numeric",
+              })}
+            </div>
+          </div>
+          <div className="text-sm font-semibold text-accent tabular-nums">
+            {pr.weight} lbs
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/app/(app)/dashboard/WeeklyVolumeChart.tsx
+++ b/app/(app)/dashboard/WeeklyVolumeChart.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+
+export interface VolumeDataPoint {
+  day: string;
+  sets: number;
+}
+
+interface WeeklyVolumeChartProps {
+  data: VolumeDataPoint[];
+}
+
+export default function WeeklyVolumeChart({ data }: WeeklyVolumeChartProps) {
+  const maxSets = Math.max(...data.map((d) => d.sets), 1);
+
+  if (data.every((d) => d.sets === 0)) {
+    return (
+      <div className="flex items-center justify-center text-content-muted text-sm h-[180px]">
+        No sets logged in the last 7 days
+      </div>
+    );
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={180}>
+      <BarChart data={data} margin={{ top: 8, right: 8, left: -20, bottom: 0 }}>
+        <CartesianGrid
+          strokeDasharray="3 3"
+          stroke="#C8B99D"
+          vertical={false}
+          opacity={0.4}
+        />
+        <XAxis
+          dataKey="day"
+          tick={{ fill: "#988A78", fontSize: 11 }}
+          axisLine={{ stroke: "#C8B99D" }}
+          tickLine={false}
+        />
+        <YAxis
+          allowDecimals={false}
+          domain={[0, Math.ceil(maxSets * 1.2)]}
+          tick={{ fill: "#988A78", fontSize: 11 }}
+          axisLine={false}
+          tickLine={false}
+          width={30}
+        />
+        <Tooltip
+          contentStyle={{
+            background: "#E8DECE",
+            border: "1px solid #C8B99D",
+            borderRadius: 8,
+            color: "#2C1A10",
+            fontSize: 13,
+          }}
+          cursor={{ fill: "#DDD2BF", opacity: 0.5 }}
+          formatter={(value: any) => [`${value} sets`, "Volume"]}
+        />
+        <Bar
+          dataKey="sets"
+          fill="#C84B1A"
+          radius={[4, 4, 0, 0]}
+          maxBarSize={32}
+        />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -3,13 +3,17 @@ import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
 import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Dumbbell, TrendingUp, BarChart3, ChevronRight } from "lucide-react";
+import { Dumbbell, TrendingUp, BarChart3, ChevronRight, Calendar, Trophy } from "lucide-react";
 import { calculateCurrentStreak } from "@/lib/milestone-utils";
 import { calculateProgressPercentage } from "@/lib/progress-utils";
 import StreakBadge from "@/components/StreakBadge";
 import CoachNotesBanner from "@/components/CoachNotesBanner";
 import LogWorkoutButton from "@/components/LogWorkoutButton";
 import GettingStartedCard from "@/components/GettingStartedCard";
+import WeeklyVolumeChart from "./WeeklyVolumeChart";
+import type { VolumeDataPoint } from "./WeeklyVolumeChart";
+import RecentPRs from "./RecentPRs";
+import type { PREntry } from "./RecentPRs";
 
 export default async function DashboardPage() {
   const supabase = await createClient();
@@ -29,8 +33,8 @@ export default async function DashboardPage() {
 
   return (
     <div>
-      <div className="flex items-start justify-between mb-1">
-        <h1 className="text-2xl font-bold text-content-primary font-display">
+      <div className="flex items-start justify-between gap-3 mb-1">
+        <h1 className="text-xl sm:text-2xl font-bold text-content-primary font-display">
           Welcome back, {firstName}
         </h1>
         <LogWorkoutButton />
@@ -95,6 +99,68 @@ async function DashboardWidgets({ userId, hasCoach }: { userId: string; hasCoach
   const nextWeek = nextTemplate
     ? Math.ceil(nextTemplate.session_number / 3)
     : null;
+
+  // ── Weekly Volume (last 7 days of set_logs) ──────────────────────────────
+  const sevenDaysAgo = new Date();
+  sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 6);
+  sevenDaysAgo.setHours(0, 0, 0, 0);
+
+  const completedLogIds = completedLogs.map(l => l.id);
+
+  const { data: recentSetLogs } = completedLogIds.length > 0
+    ? await supabase
+        .from("set_logs")
+        .select("id, logged_at, session_log_id")
+        .in("session_log_id", completedLogIds)
+        .gte("logged_at", sevenDaysAgo.toISOString())
+        .eq("is_completed", true)
+    : { data: [] };
+
+  const dayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+  const volumeByDay = new Map<string, number>();
+
+  // Pre-fill last 7 days
+  for (let i = 0; i < 7; i++) {
+    const d = new Date();
+    d.setDate(d.getDate() - (6 - i));
+    const key = d.toISOString().slice(0, 10);
+    volumeByDay.set(key, 0);
+  }
+
+  for (const sl of recentSetLogs ?? []) {
+    const dateKey = sl.logged_at.slice(0, 10);
+    if (volumeByDay.has(dateKey)) {
+      volumeByDay.set(dateKey, (volumeByDay.get(dateKey) ?? 0) + 1);
+    }
+  }
+
+  const volumeData: VolumeDataPoint[] = Array.from(volumeByDay.entries()).map(
+    ([dateStr, sets]) => ({
+      day: dayNames[new Date(dateStr + "T12:00:00").getDay()],
+      sets,
+    })
+  );
+
+  // ── Upcoming Sessions (next 2-3 incomplete) ──────────────────────────────
+  const upcomingSessions = allTemplates
+    .filter(t => !completedTemplateIds.has(t.id))
+    .slice(0, 3);
+
+  // ── Recent PRs (heaviest weight per exercise) ────────────────────────────
+  const { data: recentPRs } = await supabase
+    .from("personal_records")
+    .select("weight, achieved_at, exercise:exercises(name)")
+    .eq("user_id", userId)
+    .order("achieved_at", { ascending: false })
+    .limit(5);
+
+  const prEntries: PREntry[] = (recentPRs ?? [])
+    .filter((pr: any) => pr.exercise?.name)
+    .map((pr: any) => ({
+      exerciseName: pr.exercise.name as string,
+      weight: pr.weight as number,
+      achievedAt: pr.achieved_at as string,
+    }));
 
   return (
     <div className="space-y-6">
@@ -200,6 +266,86 @@ async function DashboardWidgets({ userId, hasCoach }: { userId: string; hasCoach
           subtitle="Track your lifts"
         />
       </div>
+
+      {/* Bottom row: Weekly Volume + Upcoming Sessions + Recent PRs */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {/* Weekly Volume Chart */}
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-lg flex items-center gap-2">
+              <BarChart3 className="h-5 w-5 text-accent" />
+              Weekly Volume
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <WeeklyVolumeChart data={volumeData} />
+          </CardContent>
+        </Card>
+
+        {/* Upcoming Sessions */}
+        <Card>
+          <CardHeader className="pb-3">
+            <div className="flex items-center justify-between">
+              <CardTitle className="text-lg flex items-center gap-2">
+                <Calendar className="h-5 w-5 text-brand" />
+                Upcoming
+              </CardTitle>
+              <Link
+                href="/sessions"
+                className="text-xs text-accent hover:text-accent-dim transition-colors flex items-center gap-0.5"
+              >
+                All <ChevronRight className="h-3 w-3" />
+              </Link>
+            </div>
+          </CardHeader>
+          <CardContent>
+            {upcomingSessions.length === 0 ? (
+              <p className="text-content-muted text-sm py-6 text-center">
+                All sessions complete!
+              </p>
+            ) : (
+              <ul className="space-y-3">
+                {upcomingSessions.map((t) => (
+                  <li key={t.id} className="flex items-center gap-3">
+                    <div className="flex-shrink-0 h-8 w-8 rounded-full bg-brand/10 flex items-center justify-center">
+                      <Dumbbell className="h-4 w-4 text-brand" />
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <div className="text-sm font-medium text-content-primary truncate">
+                        {t.title}
+                      </div>
+                      <div className="text-xs text-content-muted">
+                        Week {t.week_number} · Day {t.day_label}
+                      </div>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Recent PRs */}
+        <Card>
+          <CardHeader className="pb-3">
+            <div className="flex items-center justify-between">
+              <CardTitle className="text-lg flex items-center gap-2">
+                <Trophy className="h-5 w-5 text-warning" />
+                Recent PRs
+              </CardTitle>
+              <Link
+                href="/progress/milestones"
+                className="text-xs text-accent hover:text-accent-dim transition-colors flex items-center gap-0.5"
+              >
+                All <ChevronRight className="h-3 w-3" />
+              </Link>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <RecentPRs prs={prEntries} />
+          </CardContent>
+        </Card>
+      </div>
     </div>
   );
 }
@@ -237,6 +383,11 @@ function DashboardSkeleton() {
         <div className="h-20 bg-bg-elevated rounded-lg animate-pulse" />
         <div className="h-20 bg-bg-elevated rounded-lg animate-pulse" />
         <div className="h-20 bg-bg-elevated rounded-lg animate-pulse" />
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div className="h-64 bg-bg-elevated rounded-lg animate-pulse" />
+        <div className="h-64 bg-bg-elevated rounded-lg animate-pulse" />
+        <div className="h-64 bg-bg-elevated rounded-lg animate-pulse" />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- **Weekly Volume Chart** — recharts `BarChart` showing sets completed per day for the last 7 days, using accent color bars on warm parchment theme
- **Upcoming Sessions** — lists the next 2-3 incomplete sessions with title and day label
- **Recent PR Highlights** — shows the 5 most recent personal records with exercise name, weight, and date

All three widgets render in a 3-column grid below Quick Links. Dashboard skeleton updated with matching placeholders.

## Test plan
- [ ] Dashboard loads with all three new widgets below Quick Links
- [ ] Volume chart shows bars for days with logged sets, empty state when no recent sets
- [ ] Upcoming sessions lists the correct next incomplete sessions
- [ ] Recent PRs shows heaviest lifts with correct exercise names
- [ ] No regressions on existing Next Session, Progress, Quick Links cards
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm test` — 614 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)