### PR TITLE
feat: add mobile hamburger menu and fix responsive layout issues

### DIFF
--- a/app/(admin)/analytics/analytics-dashboard.tsx
+++ b/app/(admin)/analytics/analytics-dashboard.tsx
@@ -87,7 +87,7 @@ export function AnalyticsDashboard({ data }: { data: AnalyticsData }) {
       </div>
 
       {/* Coach Workload Section */}
-      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 24 }}>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         {/* Bar Chart */}
         <Card style={{ backgroundColor: "#E8DECE", border: "1px solid #C8B99D" }}>
           <CardHeader>

--- a/app/(admin)/programs/[id]/page.tsx
+++ b/app/(admin)/programs/[id]/page.tsx
@@ -157,8 +157,8 @@ export default function ProgramEditorPage() {
 
   if (loading) {
     return (
-      <div style={{ padding: 24 }}>
-        <div style={{ marginBottom: 24 }}>
+      <div className="p-4 sm:p-6">
+        <div className="mb-6">
           <Link href="/admin/programs">
             <Button variant="outline" size="sm" className="mb-4 flex items-center gap-2">
               <ArrowLeft className="w-4 h-4" />
@@ -166,15 +166,15 @@ export default function ProgramEditorPage() {
             </Button>
           </Link>
         </div>
-        <p style={{ color: "#6B5A48" }}>Loading program...</p>
+        <p className="text-content-secondary">Loading program...</p>
       </div>
     );
   }
 
   if (!program) {
     return (
-      <div style={{ padding: 24 }}>
-        <div style={{ marginBottom: 24 }}>
+      <div className="p-4 sm:p-6">
+        <div className="mb-6">
           <Link href="/admin/programs">
             <Button variant="outline" size="sm" className="mb-4 flex items-center gap-2">
               <ArrowLeft className="w-4 h-4" />
@@ -182,25 +182,25 @@ export default function ProgramEditorPage() {
             </Button>
           </Link>
         </div>
-        <p style={{ color: "#B83020" }}>Program not found</p>
+        <p className="text-error">Program not found</p>
       </div>
     );
   }
 
   return (
-    <div style={{ padding: 24 }}>
-      <div style={{ marginBottom: 24 }}>
+    <div className="p-4 sm:p-6">
+      <div className="mb-6">
         <Link href="/admin/programs">
           <Button variant="outline" size="sm" className="mb-4 flex items-center gap-2">
             <ArrowLeft className="w-4 h-4" />
             Back to Programs
           </Button>
         </Link>
-        
-        <h1 style={{ fontSize: 24, fontWeight: 700, color: "#2C1A10", fontFamily: "var(--font-space-grotesk)", marginBottom: 4 }}>
+
+        <h1 className="text-xl sm:text-2xl font-bold text-content-primary font-display mb-1">
           Edit Program
         </h1>
-        <p style={{ color: "#6B5A48", fontSize: 14 }}>
+        <p className="text-sm text-content-secondary">
           Manage program details and phase structure
         </p>
       </div>
@@ -288,7 +288,7 @@ export default function ProgramEditorPage() {
               )}
             </div>
 
-            <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16 }}>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div>
                 <Label htmlFor="total_phases">Total Phases</Label>
                 {editingProgram ? (
@@ -426,8 +426,8 @@ export default function ProgramEditorPage() {
                     </CardHeader>
                     <CardContent>
                       {editingPhase === phase.id ? (
-                        <div style={{ display: "grid", gap: 12 }}>
-                          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
+                        <div className="grid gap-3">
+                          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                             <div>
                               <Label htmlFor={`week_start_${phase.id}`}>Start Week</Label>
                               <Input

--- a/app/(admin)/users/page.tsx
+++ b/app/(admin)/users/page.tsx
@@ -152,23 +152,23 @@ export default function AdminUsersPage() {
 
   if (loading) {
     return (
-      <div style={{ padding: 24 }}>
-        <h1 style={{ fontSize: 24, fontWeight: 700, color: "#2C1A10", fontFamily: "var(--font-space-grotesk)", marginBottom: 16 }}>
+      <div className="p-4 sm:p-6">
+        <h1 className="text-xl sm:text-2xl font-bold text-content-primary font-display mb-4">
           Users
         </h1>
-        <p style={{ color: "#6B5A48" }}>Loading users...</p>
+        <p className="text-content-secondary">Loading users...</p>
       </div>
     );
   }
 
   return (
-    <div style={{ padding: 24 }}>
-      <div style={{ marginBottom: 24, display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
+    <div className="p-4 sm:p-6">
+      <div className="flex flex-col sm:flex-row sm:items-start justify-between gap-3 mb-6">
         <div>
-          <h1 style={{ fontSize: 24, fontWeight: 700, color: "#2C1A10", fontFamily: "var(--font-space-grotesk)", marginBottom: 4 }}>
+          <h1 className="text-xl sm:text-2xl font-bold text-content-primary font-display mb-1">
             Users
           </h1>
-          <p style={{ color: "#6B5A48", fontSize: 14 }}>
+          <p className="text-sm text-content-secondary">
             Manage user accounts, roles, and coach assignments
           </p>
         </div>
@@ -188,6 +188,7 @@ export default function AdminUsersPage() {
           </CardDescription>
         </CardHeader>
         <CardContent>
+          <div className="overflow-x-auto -mx-6 px-6">
           <Table>
             <TableHeader>
               <TableRow>
@@ -388,6 +389,7 @@ export default function AdminUsersPage() {
               ))}
             </TableBody>
           </Table>
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -29,8 +29,8 @@ export default async function DashboardPage() {
 
   return (
     <div>
-      <div className="flex items-start justify-between mb-1">
-        <h1 className="text-2xl font-bold text-content-primary font-display">
+      <div className="flex items-start justify-between gap-3 mb-1">
+        <h1 className="text-xl sm:text-2xl font-bold text-content-primary font-display">
           Welcome back, {firstName}
         </h1>
         <LogWorkoutButton />

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -29,7 +29,7 @@ export default async function AppLayout({ children }: { children: React.ReactNod
     <div style={{ minHeight: "100vh", background: "#EDE4D3" }}>
       <Sidebar role={role} hasCoach={hasCoach} />
       <div className="lg:ml-[220px] flex flex-col min-h-screen">
-        <Header fullName={fullName} />
+        <Header fullName={fullName} role={role} hasCoach={hasCoach} />
         <main className="flex-1 px-4 py-6">{children}</main>
       </div>
     </div>

--- a/app/(app)/progress/charts/ChartContainer.tsx
+++ b/app/(app)/progress/charts/ChartContainer.tsx
@@ -69,7 +69,7 @@ export default function ChartContainer({ userId }: ChartContainerProps) {
 
       {/* Chart Display */}
       <div className="lg:col-span-2">
-        <div className="bg-bg-elevated border border-border-subtle rounded-lg p-6">
+        <div className="bg-bg-elevated border border-border-subtle rounded-lg p-3 sm:p-6">
           {!selectedExerciseId ? (
             <div className="flex items-center justify-center h-80 text-content-muted text-sm">
               Select an exercise to view its progress chart

--- a/app/(app)/progress/charts/page.tsx
+++ b/app/(app)/progress/charts/page.tsx
@@ -15,16 +15,16 @@ export default async function ChartsPage() {
 
   return (
     <div>
-      <div className="flex items-center gap-4 mb-6">
+      <div className="flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-4 mb-6">
         <Link
           href="/progress"
-          className="inline-flex items-center gap-2 px-3 py-2 text-content-secondary hover:text-content-primary hover:bg-bg-hover rounded-lg transition-colors"
+          className="inline-flex items-center gap-2 px-3 py-2 text-content-secondary hover:text-content-primary hover:bg-bg-hover rounded-lg transition-colors self-start"
         >
           <ArrowLeft size={16} />
           Back to Progress
         </Link>
         <div>
-          <h1 className="text-2xl font-bold text-content-primary font-display mb-1">
+          <h1 className="text-xl sm:text-2xl font-bold text-content-primary font-display mb-1">
             Lift Charts
           </h1>
           <p className="text-sm text-content-secondary">

--- a/app/(app)/sessions/SessionCard.tsx
+++ b/app/(app)/sessions/SessionCard.tsx
@@ -141,17 +141,17 @@ export default function SessionCard({
   return (
     <Card className="transition-all duration-200">
       <CardHeader className="pb-3">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <span className="text-sm font-medium text-content-muted">Day {dayLabel}</span>
-            <span className="text-content-muted">•</span>
-            <h3 className="text-base font-semibold text-content-primary">{sessionTitle}</h3>
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-2 sm:gap-3 min-w-0">
+            <span className="text-sm font-medium text-content-muted shrink-0">Day {dayLabel}</span>
+            <span className="text-content-muted hidden sm:inline">•</span>
+            <h3 className="text-sm sm:text-base font-semibold text-content-primary truncate">{sessionTitle}</h3>
           </div>
 
-          <div className="flex items-center gap-3">
+          <div className="flex items-center gap-2 sm:gap-3 shrink-0">
             <div className={`px-2 py-1 rounded-full text-xs font-medium flex items-center gap-1 ${statusInfo.color}`}>
               {statusInfo.icon}
-              <span>{statusInfo.text}</span>
+              <span className="hidden sm:inline">{statusInfo.text}</span>
             </div>
             <button
               type="button"
@@ -219,7 +219,7 @@ export default function SessionCard({
               {!loadingExercises && exercises.map(({ templateExercise, setLogs }) => (
                 <div key={templateExercise.id} className="space-y-2">
                   {/* Exercise header */}
-                  <div className="flex items-baseline gap-2">
+                  <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
                     <span className="text-sm font-semibold text-content-primary">
                       {templateExercise.exercise?.name ?? "Exercise"}
                     </span>
@@ -234,14 +234,14 @@ export default function SessionCard({
                       </span>
                     )}
                     {templateExercise.coaching_cues && (
-                      <span className="text-xs text-content-secondary italic ml-auto">{templateExercise.coaching_cues}</span>
+                      <span className="text-xs text-content-secondary italic sm:ml-auto">{templateExercise.coaching_cues}</span>
                     )}
                     {templateExercise.exercise?.video_url && (
                       <a
                         href={templateExercise.exercise.video_url}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="ml-auto text-content-muted hover:text-accent transition-colors"
+                        className="sm:ml-auto text-content-muted hover:text-accent transition-colors"
                         title="Watch demo video"
                       >
                         <Video className="w-4 h-4" />
@@ -250,11 +250,11 @@ export default function SessionCard({
                   </div>
 
                   {/* Column headers */}
-                  <div className="flex items-center gap-3 px-3 text-xs text-content-muted">
-                    <span className="w-6 text-center">Set</span>
+                  <div className="flex items-center gap-2 sm:gap-3 px-2 sm:px-3 text-xs text-content-muted">
+                    <span className="w-6 text-center shrink-0">Set</span>
                     <span className="flex-1">Weight</span>
-                    <span className="min-w-[84px] text-center">Reps</span>
-                    <span className="w-8" />
+                    <span className="min-w-[70px] sm:min-w-[84px] text-center">Reps</span>
+                    <span className="w-8 shrink-0" />
                   </div>
 
                   {/* Set rows */}

--- a/app/(app)/sessions/SetRow.tsx
+++ b/app/(app)/sessions/SetRow.tsx
@@ -63,7 +63,7 @@ export default function SetRow({
 
   return (
     <div
-      className={`flex items-center gap-3 px-3 py-2 rounded-lg transition-colors ${
+      className={`flex items-center gap-2 sm:gap-3 px-2 sm:px-3 py-2 rounded-lg transition-colors ${
         isLogged ? "bg-success/8 border border-success/20" : "bg-bg-surface border border-transparent"
       }`}
     >
@@ -88,12 +88,12 @@ export default function SetRow({
           type="button"
           onClick={() => setReps((r) => Math.max(1, r - 1))}
           disabled={isLogged || reps <= 1}
-          className="w-7 h-7 flex items-center justify-center rounded-md text-content-secondary border border-border-subtle bg-bg-surface hover:bg-bg-hover disabled:opacity-30 disabled:cursor-not-allowed transition-colors text-sm font-medium"
+          className="w-7 h-7 flex items-center justify-center rounded-md text-content-secondary border border-border-subtle bg-bg-surface hover:bg-bg-hover disabled:opacity-30 disabled:cursor-not-allowed transition-colors text-sm font-medium shrink-0"
           aria-label="Decrease reps"
         >
           −
         </button>
-        <span className="min-w-[40px] text-center text-sm font-semibold text-content-primary">
+        <span className="min-w-[32px] sm:min-w-[40px] text-center text-xs sm:text-sm font-semibold text-content-primary">
           {reps}
           <span className="text-xs text-content-muted ml-0.5">r</span>
         </span>
@@ -101,7 +101,7 @@ export default function SetRow({
           type="button"
           onClick={() => setReps((r) => r + 1)}
           disabled={isLogged}
-          className="w-7 h-7 flex items-center justify-center rounded-md text-content-secondary border border-border-subtle bg-bg-surface hover:bg-bg-hover disabled:opacity-30 disabled:cursor-not-allowed transition-colors text-sm font-medium"
+          className="w-7 h-7 flex items-center justify-center rounded-md text-content-secondary border border-border-subtle bg-bg-surface hover:bg-bg-hover disabled:opacity-30 disabled:cursor-not-allowed transition-colors text-sm font-medium shrink-0"
           aria-label="Increase reps"
         >
           +

--- a/app/(app)/sessions/WeightControl.tsx
+++ b/app/(app)/sessions/WeightControl.tsx
@@ -31,19 +31,19 @@ export default function WeightControl({
         type="button"
         onClick={() => onChange(Math.max(min, value - step))}
         disabled={disabled || value <= min}
-        className="w-7 h-7 flex items-center justify-center rounded-md text-content-secondary border border-border-subtle bg-bg-surface hover:bg-bg-hover hover:text-content-primary disabled:opacity-30 disabled:cursor-not-allowed transition-colors text-sm font-medium"
+        className="w-7 h-7 flex items-center justify-center rounded-md text-content-secondary border border-border-subtle bg-bg-surface hover:bg-bg-hover hover:text-content-primary disabled:opacity-30 disabled:cursor-not-allowed transition-colors text-sm font-medium shrink-0"
         aria-label={`Decrease by ${step}`}
       >
         −
       </button>
-      <span className="min-w-[52px] text-center text-sm font-semibold text-content-primary">
-        {value} lbs
+      <span className="min-w-[44px] sm:min-w-[52px] text-center text-xs sm:text-sm font-semibold text-content-primary">
+        {value}<span className="hidden sm:inline"> lbs</span><span className="sm:hidden">lb</span>
       </span>
       <button
         type="button"
         onClick={() => onChange(value + step)}
         disabled={disabled}
-        className="w-7 h-7 flex items-center justify-center rounded-md text-content-secondary border border-border-subtle bg-bg-surface hover:bg-bg-hover hover:text-content-primary disabled:opacity-30 disabled:cursor-not-allowed transition-colors text-sm font-medium"
+        className="w-7 h-7 flex items-center justify-center rounded-md text-content-secondary border border-border-subtle bg-bg-surface hover:bg-bg-hover hover:text-content-primary disabled:opacity-30 disabled:cursor-not-allowed transition-colors text-sm font-medium shrink-0"
         aria-label={`Increase by ${step}`}
       >
         +

--- a/components/LiftChart.tsx
+++ b/components/LiftChart.tsx
@@ -28,7 +28,7 @@ export default function LiftChart({ data, exerciseName, height = 300 }: LiftChar
 
   return (
     <ResponsiveContainer width="100%" height={height}>
-      <LineChart data={data} margin={{ top: 5, right: 30, left: 20, bottom: 5 }}>
+      <LineChart data={data} margin={{ top: 5, right: 10, left: 0, bottom: 5 }}>
         <CartesianGrid 
           strokeDasharray="3 3" 
           stroke="#C8B99D" 

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -1,40 +1,66 @@
 "use client";
 
-import { LogOut } from "lucide-react";
+import { useState } from "react";
+import { LogOut, Menu } from "lucide-react";
 import { signOut } from "@/lib/actions/auth";
+import { MobileNav } from "./MobileNav";
+import type { UserRole } from "@/lib/types";
 
 interface HeaderProps {
   fullName: string;
+  role?: UserRole;
+  hasCoach?: boolean;
 }
 
-export function Header({ fullName }: HeaderProps) {
+export function Header({ fullName, role = "user", hasCoach = false }: HeaderProps) {
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
+
   return (
-    <header className="sticky top-0 z-10 bg-bg-surface border-b border-border-subtle px-4 h-14 flex items-center justify-between">
-      {/* Mobile logo */}
-      <span className="lg:hidden text-lg font-bold font-display">
-        <span className="text-brand">Build</span>
-        <span className="text-accent font-bold">Base</span>
-      </span>
-
-      {/* Spacer for desktop (sidebar takes left side) */}
-      <div className="hidden lg:block" />
-
-      {/* Right: user name + sign out */}
-      <div className="flex items-center gap-3">
-        <span className="text-[13px] text-content-secondary max-w-[160px] truncate">
-          {fullName}
-        </span>
-
-        <form action={signOut}>
+    <>
+      <header className="sticky top-0 z-10 bg-bg-surface border-b border-border-subtle px-4 h-14 flex items-center justify-between">
+        {/* Left: hamburger + mobile logo */}
+        <div className="flex items-center gap-2 lg:hidden">
           <button
-            type="submit"
-            title="Sign out"
-            className="flex items-center justify-center w-8 h-8 rounded-lg bg-transparent border border-border-subtle text-content-secondary cursor-pointer transition-colors hover:border-border-strong hover:text-content-primary"
+            type="button"
+            onClick={() => setMobileNavOpen(true)}
+            className="flex items-center justify-center w-8 h-8 rounded-lg text-content-secondary hover:text-content-primary hover:bg-bg-hover transition-colors"
+            aria-label="Open menu"
           >
-            <LogOut size={15} />
+            <Menu size={20} />
           </button>
-        </form>
-      </div>
-    </header>
+          <span className="text-lg font-bold font-display">
+            <span className="text-brand">Build</span>
+            <span className="text-accent font-bold">Base</span>
+          </span>
+        </div>
+
+        {/* Spacer for desktop (sidebar takes left side) */}
+        <div className="hidden lg:block" />
+
+        {/* Right: user name + sign out */}
+        <div className="flex items-center gap-3">
+          <span className="text-[13px] text-content-secondary max-w-[160px] truncate">
+            {fullName}
+          </span>
+
+          <form action={signOut}>
+            <button
+              type="submit"
+              title="Sign out"
+              className="flex items-center justify-center w-8 h-8 rounded-lg bg-transparent border border-border-subtle text-content-secondary cursor-pointer transition-colors hover:border-border-strong hover:text-content-primary"
+            >
+              <LogOut size={15} />
+            </button>
+          </form>
+        </div>
+      </header>
+
+      <MobileNav
+        role={role}
+        hasCoach={hasCoach}
+        open={mobileNavOpen}
+        onClose={() => setMobileNavOpen(false)}
+      />
+    </>
   );
 }

--- a/components/layout/MobileNav.tsx
+++ b/components/layout/MobileNav.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { X } from "lucide-react";
+import {
+  LayoutDashboard,
+  Dumbbell,
+  TrendingUp,
+  MessageSquare,
+  Users,
+  BookOpen,
+  UserCog,
+  ClipboardList,
+  BarChart3,
+} from "lucide-react";
+import { getNavItems, type NavItem } from "@/lib/profile";
+import type { UserRole } from "@/lib/types";
+
+const ICON_MAP: Record<string, React.ElementType> = {
+  LayoutDashboard,
+  Dumbbell,
+  TrendingUp,
+  MessageSquare,
+  Users,
+  BookOpen,
+  UserCog,
+  ClipboardList,
+  BarChart3,
+};
+
+interface MobileNavProps {
+  role: UserRole;
+  hasCoach: boolean;
+  open: boolean;
+  onClose: () => void;
+}
+
+export function MobileNav({ role, hasCoach, open, onClose }: MobileNavProps) {
+  const pathname = usePathname();
+  const items = getNavItems(role, hasCoach);
+
+  // Lock body scroll when open
+  useEffect(() => {
+    if (open) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [open]);
+
+  // Close on Escape key
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    if (open) {
+      document.addEventListener("keydown", handleKeyDown);
+    }
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 lg:hidden">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/40"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Drawer */}
+      <aside className="absolute top-0 left-0 w-[280px] h-full bg-bg-surface border-r border-border-subtle flex flex-col py-5 shadow-xl animate-in slide-in-from-left duration-200">
+        {/* Header with logo + close button */}
+        <div className="px-5 pb-5 border-b border-border-subtle mb-3 flex items-center justify-between">
+          <Link href="/dashboard" className="no-underline" onClick={onClose}>
+            <span className="text-xl font-bold font-display">
+              <span className="text-brand">Build</span>
+              <span className="text-accent">Base</span>
+            </span>
+          </Link>
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex items-center justify-center w-8 h-8 rounded-lg text-content-secondary hover:text-content-primary hover:bg-bg-hover transition-colors"
+            aria-label="Close menu"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        {/* Nav items */}
+        <nav className="flex-1 px-3 overflow-y-auto">
+          {items.map((item: NavItem) => {
+            const Icon = ICON_MAP[item.icon];
+            const isActive =
+              item.href === "/dashboard"
+                ? pathname === "/dashboard"
+                : pathname.startsWith(item.href);
+
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                onClick={onClose}
+                className={[
+                  "flex items-center gap-2.5 px-3 py-2.5 rounded-lg no-underline text-sm mb-0.5 transition-colors",
+                  isActive
+                    ? "text-content-primary bg-bg-hover font-semibold"
+                    : "text-content-secondary bg-transparent font-medium hover:bg-bg-hover hover:text-content-primary",
+                ].join(" ")}
+              >
+                {Icon && <Icon size={18} />}
+                {item.label}
+              </Link>
+            );
+          })}
+        </nav>
+
+        {/* Role badge */}
+        <div className="px-5 pt-3 border-t border-border-subtle">
+          <span className="text-[11px] font-semibold uppercase tracking-[0.08em] text-content-muted">
+            {role}
+          </span>
+        </div>
+      </aside>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **Mobile hamburger menu** — new `MobileNav` slide-over drawer with backdrop, close button, Escape key, body scroll lock, and auto-close on nav click
- **Session cards** — responsive gaps, truncating titles, compact status icons on mobile
- **Set rows / weight controls** — tighter padding and min-widths on small screens, "lb" vs "lbs" label
- **Admin pages** — `overflow-x-auto` on user table, stacking grids on mobile for programs editor
- **Charts** — reduced margins and tighter padding for mobile fit

13 files changed, +241/-78 lines.

## Test plan
- [ ] Hamburger menu appears on mobile, opens slide-over drawer with correct nav items
- [ ] Drawer closes on nav click, close button, Escape key, and backdrop click
- [ ] Session cards and set rows don't overflow on 375px width
- [ ] Admin users table scrolls horizontally on mobile
- [ ] Programs editor phase/weeks grid stacks on mobile
- [ ] Charts resize properly on narrow screens
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm test` — 614 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)