### PR TITLE
feat: add in-app notification center with bell dropdown

### DIFF
--- a/app/api/notifications/[id]/route.ts
+++ b/app/api/notifications/[id]/route.ts
@@ -1,0 +1,45 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextRequest, NextResponse } from "next/server";
+
+// PATCH /api/notifications/[id] — mark a single notification as read
+export async function PATCH(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { data, error } = await supabase
+      .from("notifications")
+      .update({ read_at: new Date().toISOString() })
+      .eq("id", id)
+      .eq("user_id", user.id)
+      .select("id")
+      .single();
+
+    if (error || !data) {
+      console.error("Error marking notification as read:", error);
+      return NextResponse.json(
+        { error: "Notification not found" },
+        { status: 404 },
+      );
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Error in PATCH /api/notifications/[id]:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -1,0 +1,75 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+
+// GET /api/notifications — list user's notifications, newest first, limit 20
+export async function GET() {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { data: notifications, error } = await supabase
+      .from("notifications")
+      .select("*")
+      .eq("user_id", user.id)
+      .order("created_at", { ascending: false })
+      .limit(20);
+
+    if (error) {
+      console.error("Error fetching notifications:", error);
+      return NextResponse.json(
+        { error: "Failed to fetch notifications" },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json(notifications ?? []);
+  } catch (error) {
+    console.error("Error in GET /api/notifications:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}
+
+// PATCH /api/notifications — mark all as read
+export async function PATCH() {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { error } = await supabase
+      .from("notifications")
+      .update({ read_at: new Date().toISOString() })
+      .eq("user_id", user.id)
+      .is("read_at", null);
+
+    if (error) {
+      console.error("Error marking notifications as read:", error);
+      return NextResponse.json(
+        { error: "Failed to mark notifications as read" },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Error in PATCH /api/notifications:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/components/NotificationBell.tsx
+++ b/components/NotificationBell.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { Bell, MessageSquare, Trophy, Info, Check } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { apiFetchJson } from "@/lib/api-helpers";
+import type { Notification, NotificationType } from "@/lib/types";
+
+const POLL_INTERVAL = 30_000; // 30 seconds
+
+function typeIcon(type: NotificationType) {
+  switch (type) {
+    case "coach_note":
+      return <MessageSquare size={16} className="text-accent shrink-0" />;
+    case "milestone":
+      return <Trophy size={16} className="text-warning shrink-0" />;
+    case "system":
+      return <Info size={16} className="text-content-secondary shrink-0" />;
+  }
+}
+
+function relativeTime(dateStr: string): string {
+  const now = Date.now();
+  const then = new Date(dateStr).getTime();
+  const diffSeconds = Math.floor((now - then) / 1000);
+
+  if (diffSeconds < 60) return "just now";
+  const diffMinutes = Math.floor(diffSeconds / 60);
+  if (diffMinutes < 60) return `${diffMinutes}m ago`;
+  const diffHours = Math.floor(diffMinutes / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays < 7) return `${diffDays}d ago`;
+  return new Date(dateStr).toLocaleDateString();
+}
+
+export function NotificationBell() {
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+  const [open, setOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const router = useRouter();
+
+  const unreadCount = notifications.filter((n) => !n.read_at).length;
+
+  const fetchNotifications = useCallback(async () => {
+    try {
+      const data = await apiFetchJson<Notification[]>("/api/notifications");
+      setNotifications(data);
+    } catch {
+      // Silently fail on poll — user doesn't need to see this
+    }
+  }, []);
+
+  // Fetch on mount and poll every 30 seconds
+  useEffect(() => {
+    fetchNotifications();
+    const interval = setInterval(fetchNotifications, POLL_INTERVAL);
+    return () => clearInterval(interval);
+  }, [fetchNotifications]);
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(e.target as Node) &&
+        buttonRef.current &&
+        !buttonRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    }
+    if (open) {
+      document.addEventListener("mousedown", handleClickOutside);
+      return () =>
+        document.removeEventListener("mousedown", handleClickOutside);
+    }
+  }, [open]);
+
+  async function markAllRead() {
+    try {
+      await apiFetchJson("/api/notifications", { method: "PATCH" });
+      setNotifications((prev) =>
+        prev.map((n) => ({
+          ...n,
+          read_at: n.read_at ?? new Date().toISOString(),
+        })),
+      );
+    } catch {
+      // Best-effort
+    }
+  }
+
+  async function handleNotificationClick(notification: Notification) {
+    // Mark as read
+    if (!notification.read_at) {
+      try {
+        await apiFetchJson(`/api/notifications/${notification.id}`, {
+          method: "PATCH",
+        });
+        setNotifications((prev) =>
+          prev.map((n) =>
+            n.id === notification.id
+              ? { ...n, read_at: new Date().toISOString() }
+              : n,
+          ),
+        );
+      } catch {
+        // Best-effort
+      }
+    }
+
+    // Navigate if link exists
+    if (notification.link) {
+      setOpen(false);
+      router.push(notification.link);
+    }
+  }
+
+  return (
+    <div className="relative">
+      <button
+        ref={buttonRef}
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        className="relative flex items-center justify-center w-8 h-8 rounded-lg bg-transparent border border-border-subtle text-content-secondary cursor-pointer transition-colors hover:border-border-strong hover:text-content-primary"
+        aria-label={`Notifications${unreadCount > 0 ? ` (${unreadCount} unread)` : ""}`}
+      >
+        <Bell size={15} />
+        {unreadCount > 0 && (
+          <span className="absolute -top-1 -right-1 flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded-full bg-error text-button-text text-[10px] font-bold leading-none">
+            {unreadCount > 99 ? "99+" : unreadCount}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div
+          ref={dropdownRef}
+          className="absolute right-0 top-full mt-2 w-80 max-h-96 overflow-y-auto rounded-lg border border-border-subtle bg-bg-elevated shadow-lg z-50"
+        >
+          {/* Header */}
+          <div className="sticky top-0 flex items-center justify-between px-4 py-3 border-b border-border-subtle bg-bg-elevated">
+            <span className="text-sm font-semibold text-content-primary">
+              Notifications
+            </span>
+            {unreadCount > 0 && (
+              <button
+                type="button"
+                onClick={markAllRead}
+                className="flex items-center gap-1 text-xs text-accent hover:text-accent-dim transition-colors cursor-pointer"
+              >
+                <Check size={12} />
+                Mark all as read
+              </button>
+            )}
+          </div>
+
+          {/* List */}
+          {notifications.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-10 px-4">
+              <Bell size={24} className="text-content-muted mb-2" />
+              <p className="text-sm text-content-muted">
+                You&apos;re all caught up!
+              </p>
+            </div>
+          ) : (
+            <ul className="divide-y divide-border-subtle">
+              {notifications.map((n) => (
+                <li key={n.id}>
+                  <button
+                    type="button"
+                    onClick={() => handleNotificationClick(n)}
+                    className={`w-full text-left flex gap-3 px-4 py-3 transition-colors cursor-pointer hover:bg-bg-hover ${
+                      !n.read_at ? "bg-bg-surface" : ""
+                    }`}
+                  >
+                    <div className="mt-0.5">{typeIcon(n.type)}</div>
+                    <div className="flex-1 min-w-0">
+                      <p
+                        className={`text-sm leading-tight ${
+                          !n.read_at
+                            ? "font-semibold text-content-primary"
+                            : "text-content-secondary"
+                        }`}
+                      >
+                        {n.title}
+                      </p>
+                      <p className="text-xs text-content-muted mt-0.5 truncate">
+                        {n.message}
+                      </p>
+                      <p className="text-[11px] text-content-muted mt-1">
+                        {relativeTime(n.created_at)}
+                      </p>
+                    </div>
+                    {!n.read_at && (
+                      <span className="mt-1.5 w-2 h-2 rounded-full bg-accent shrink-0" />
+                    )}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { LogOut, Menu } from "lucide-react";
 import { signOut } from "@/lib/actions/auth";
 import { ThemeToggle } from "@/components/ThemeToggle";
+import { NotificationBell } from "@/components/NotificationBell";
 import { MobileNav } from "./MobileNav";
 import type { UserRole } from "@/lib/types";
 
@@ -45,6 +46,8 @@ export function Header({ fullName, role = "user", hasCoach = false }: HeaderProp
           </span>
 
           <ThemeToggle />
+
+          <NotificationBell />
 
           <form action={signOut}>
             <button

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -220,6 +220,21 @@ export interface UserExerciseOverride {
   set_by_profile?: { id: string; full_name: string | null; email: string };
 }
 
+// ─── Notifications ───────────────────────────────────────────────────────────
+
+export type NotificationType = "coach_note" | "milestone" | "system";
+
+export interface Notification {
+  id: string;
+  user_id: string;
+  type: NotificationType;
+  title: string;
+  message: string;
+  link: string | null;
+  read_at: string | null;
+  created_at: string;
+}
+
 // ─── UI helpers ───────────────────────────────────────────────────────────────
 
 export interface SessionWeekGroup {

--- a/supabase/migrations/010_notifications.sql
+++ b/supabase/migrations/010_notifications.sql
@@ -1,0 +1,23 @@
+-- Notification center: unified in-app notifications
+CREATE TABLE notifications (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  type TEXT NOT NULL, -- 'coach_note', 'milestone', 'system'
+  title TEXT NOT NULL,
+  message TEXT NOT NULL,
+  link TEXT, -- optional deep link like '/coach-notes' or '/progress/milestones'
+  read_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX idx_notifications_user_unread ON notifications(user_id, read_at) WHERE read_at IS NULL;
+
+ALTER TABLE notifications ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own notifications"
+  ON notifications FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own notifications"
+  ON notifications FOR UPDATE
+  USING (auth.uid() = user_id);

--- a/tests/notifications-api.test.ts
+++ b/tests/notifications-api.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { GET, PATCH } from "@/app/api/notifications/route";
+import { PATCH as PATCH_SINGLE } from "@/app/api/notifications/[id]/route";
+
+// Mock Supabase
+const mockSupabase = {
+  auth: {
+    getUser: vi.fn(),
+  },
+  from: vi.fn().mockReturnThis(),
+  select: vi.fn().mockReturnThis(),
+  eq: vi.fn().mockReturnThis(),
+  is: vi.fn().mockReturnThis(),
+  order: vi.fn().mockReturnThis(),
+  limit: vi.fn().mockReturnThis(),
+  update: vi.fn().mockReturnThis(),
+  single: vi.fn().mockReturnThis(),
+};
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: () => mockSupabase,
+}));
+
+describe("Notifications API Routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset chain methods
+    mockSupabase.from.mockReturnValue(mockSupabase);
+    mockSupabase.select.mockReturnValue(mockSupabase);
+    mockSupabase.eq.mockReturnValue(mockSupabase);
+    mockSupabase.is.mockReturnValue(mockSupabase);
+    mockSupabase.order.mockReturnValue(mockSupabase);
+    mockSupabase.update.mockReturnValue(mockSupabase);
+  });
+
+  describe("GET /api/notifications", () => {
+    it("should return 401 if not authenticated", async () => {
+      mockSupabase.auth.getUser.mockResolvedValue({
+        data: { user: null },
+      });
+
+      const response = await GET();
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.error).toBe("Unauthorized");
+    });
+
+    it("should return notifications for authenticated user", async () => {
+      const mockUser = { id: "user-1" };
+      const mockNotifications = [
+        {
+          id: "n-1",
+          user_id: "user-1",
+          type: "coach_note",
+          title: "New Note",
+          message: "Your coach left you a note",
+          link: "/coach-notes",
+          read_at: null,
+          created_at: "2025-01-01T00:00:00Z",
+        },
+        {
+          id: "n-2",
+          user_id: "user-1",
+          type: "milestone",
+          title: "PR Achieved!",
+          message: "You hit a new personal record on Bench Press",
+          link: "/progress/milestones",
+          read_at: "2025-01-01T01:00:00Z",
+          created_at: "2025-01-01T00:00:00Z",
+        },
+      ];
+
+      mockSupabase.auth.getUser.mockResolvedValue({
+        data: { user: mockUser },
+      });
+      mockSupabase.limit.mockResolvedValue({
+        data: mockNotifications,
+        error: null,
+      });
+
+      const response = await GET();
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data).toEqual(mockNotifications);
+      expect(data).toHaveLength(2);
+    });
+
+    it("should return empty array when no notifications", async () => {
+      mockSupabase.auth.getUser.mockResolvedValue({
+        data: { user: { id: "user-1" } },
+      });
+      mockSupabase.limit.mockResolvedValue({ data: [], error: null });
+
+      const response = await GET();
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data).toEqual([]);
+    });
+
+    it("should return 500 on database error", async () => {
+      mockSupabase.auth.getUser.mockResolvedValue({
+        data: { user: { id: "user-1" } },
+      });
+      mockSupabase.limit.mockResolvedValue({
+        data: null,
+        error: { message: "DB error" },
+      });
+
+      const response = await GET();
+      const data = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(data.error).toBe("Failed to fetch notifications");
+    });
+  });
+
+  describe("PATCH /api/notifications (mark all read)", () => {
+    it("should return 401 if not authenticated", async () => {
+      mockSupabase.auth.getUser.mockResolvedValue({
+        data: { user: null },
+      });
+
+      const response = await PATCH();
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.error).toBe("Unauthorized");
+    });
+
+    it("should mark all notifications as read", async () => {
+      mockSupabase.auth.getUser.mockResolvedValue({
+        data: { user: { id: "user-1" } },
+      });
+      mockSupabase.is.mockResolvedValue({ error: null });
+
+      const response = await PATCH();
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+    });
+
+    it("should return 500 on database error", async () => {
+      mockSupabase.auth.getUser.mockResolvedValue({
+        data: { user: { id: "user-1" } },
+      });
+      mockSupabase.is.mockResolvedValue({
+        error: { message: "DB error" },
+      });
+
+      const response = await PATCH();
+      const data = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(data.error).toBe("Failed to mark notifications as read");
+    });
+  });
+
+  describe("PATCH /api/notifications/[id] (mark single read)", () => {
+    it("should return 401 if not authenticated", async () => {
+      mockSupabase.auth.getUser.mockResolvedValue({
+        data: { user: null },
+      });
+
+      const request = new NextRequest(
+        "http://localhost/api/notifications/n-1",
+        { method: "PATCH" },
+      );
+
+      const response = await PATCH_SINGLE(request, {
+        params: Promise.resolve({ id: "n-1" }),
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.error).toBe("Unauthorized");
+    });
+
+    it("should mark a single notification as read", async () => {
+      mockSupabase.auth.getUser.mockResolvedValue({
+        data: { user: { id: "user-1" } },
+      });
+      mockSupabase.single.mockResolvedValue({
+        data: { id: "n-1" },
+        error: null,
+      });
+
+      const request = new NextRequest(
+        "http://localhost/api/notifications/n-1",
+        { method: "PATCH" },
+      );
+
+      const response = await PATCH_SINGLE(request, {
+        params: Promise.resolve({ id: "n-1" }),
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+    });
+
+    it("should return 404 if notification not found", async () => {
+      mockSupabase.auth.getUser.mockResolvedValue({
+        data: { user: { id: "user-1" } },
+      });
+      mockSupabase.single.mockResolvedValue({
+        data: null,
+        error: { message: "No rows found" },
+      });
+
+      const request = new NextRequest(
+        "http://localhost/api/notifications/nonexistent",
+        { method: "PATCH" },
+      );
+
+      const response = await PATCH_SINGLE(request, {
+        params: Promise.resolve({ id: "nonexistent" }),
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.error).toBe("Notification not found");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **Notifications table** — `010_notifications.sql` with type/title/message/link fields, partial index on unread, RLS for own-user access
- **API routes** — GET `/api/notifications` (20 most recent), PATCH `/api/notifications` (mark all read), PATCH `/api/notifications/[id]` (mark one read)
- **NotificationBell component** — Bell icon with unread count badge, click-to-open dropdown, type-based icons (coach_note/milestone/system), relative timestamps, mark-all-read, click-to-navigate, 30s polling, outside-click-to-close
- **Header integration** — Bell placed between ThemeToggle and sign-out button
- **10 API tests** covering auth, success paths, error handling, and 404 cases

## Test plan
- [ ] Bell icon shows in header with unread count badge
- [ ] Clicking bell opens dropdown with notifications
- [ ] Clicking a notification marks it read and navigates to its link
- [ ] "Mark all as read" clears the badge count
- [ ] Empty state shows "You're all caught up!"
- [ ] Dropdown closes on outside click
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm test` — 624 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)