### PR TITLE
feat: add user settings page with profile editing and preferences

### DIFF
--- a/app/(app)/settings/SettingsForm.tsx
+++ b/app/(app)/settings/SettingsForm.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { Select } from "@/components/ui/select";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { apiFetchJson } from "@/lib/api-helpers";
+import { toast } from "sonner";
+import { User, Palette, Shield } from "lucide-react";
+import type { Gender, TemplateTier, UserRole } from "@/lib/types";
+
+interface SettingsFormProps {
+  profile: {
+    id: string;
+    full_name: string | null;
+    email: string;
+    role: UserRole;
+    gender: Gender;
+    template_tier: TemplateTier;
+    coach_id: string | null;
+  };
+}
+
+const TIER_LABELS: Record<TemplateTier, string> = {
+  pre_baseline: "Pre-Baseline",
+  default: "Default",
+  post_baseline: "Post-Baseline",
+};
+
+const GENDER_OPTIONS: { value: Gender; label: string }[] = [
+  { value: "male", label: "Male" },
+  { value: "female", label: "Female" },
+  { value: "other", label: "Other" },
+  { value: "unset", label: "Prefer not to say" },
+];
+
+const THEME_OPTIONS = [
+  { value: "system", label: "System" },
+  { value: "light", label: "Light" },
+  { value: "dark", label: "Dark" },
+] as const;
+
+type ThemePreference = (typeof THEME_OPTIONS)[number]["value"];
+
+function getStoredTheme(): ThemePreference {
+  if (typeof window === "undefined") return "system";
+  const stored = localStorage.getItem("theme");
+  if (stored === "light" || stored === "dark" || stored === "system") return stored;
+  return "system";
+}
+
+export default function SettingsForm({ profile }: SettingsFormProps) {
+  const [fullName, setFullName] = useState(profile.full_name ?? "");
+  const [gender, setGender] = useState<Gender>(profile.gender);
+  const [theme, setTheme] = useState<ThemePreference>(getStoredTheme);
+  const [saving, setSaving] = useState(false);
+
+  function handleThemeChange(value: ThemePreference) {
+    setTheme(value);
+    localStorage.setItem("theme", value);
+    // Dispatch storage event so ThemeToggle picks it up
+    window.dispatchEvent(new StorageEvent("storage", { key: "theme", newValue: value }));
+  }
+
+  async function handleSave() {
+    setSaving(true);
+    try {
+      await apiFetchJson("/api/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ full_name: fullName, gender }),
+      });
+      toast.success("Settings saved");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to save settings";
+      toast.error(message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6 max-w-2xl">
+      {/* Profile Section */}
+      <Card>
+        <CardHeader className="pb-4">
+          <CardTitle className="text-lg flex items-center gap-2">
+            <User className="h-5 w-5 text-accent" />
+            Profile
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="full_name">Full Name</Label>
+            <Input
+              id="full_name"
+              value={fullName}
+              onChange={(e) => setFullName(e.target.value)}
+              placeholder="Enter your full name"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="email">Email</Label>
+            <Input
+              id="email"
+              value={profile.email}
+              disabled
+              className="opacity-60"
+            />
+            <p className="text-xs text-content-muted">Email cannot be changed</p>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="role">Role</Label>
+            <Input
+              id="role"
+              value={profile.role.charAt(0).toUpperCase() + profile.role.slice(1)}
+              disabled
+              className="opacity-60"
+            />
+            <p className="text-xs text-content-muted">Role is assigned by an administrator</p>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Preferences Section */}
+      <Card>
+        <CardHeader className="pb-4">
+          <CardTitle className="text-lg flex items-center gap-2">
+            <Palette className="h-5 w-5 text-accent" />
+            Preferences
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label>Theme</Label>
+            <RadioGroup
+              value={theme}
+              onValueChange={(v) => handleThemeChange(v as ThemePreference)}
+              className="flex gap-4"
+            >
+              {THEME_OPTIONS.map((opt) => (
+                <div key={opt.value} className="flex items-center gap-2">
+                  <RadioGroupItem value={opt.value} id={`theme-${opt.value}`} />
+                  <Label htmlFor={`theme-${opt.value}`} className="font-normal cursor-pointer">
+                    {opt.label}
+                  </Label>
+                </div>
+              ))}
+            </RadioGroup>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Account Section */}
+      <Card>
+        <CardHeader className="pb-4">
+          <CardTitle className="text-lg flex items-center gap-2">
+            <Shield className="h-5 w-5 text-accent" />
+            Account
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="gender">Gender</Label>
+            <Select
+              id="gender"
+              value={gender}
+              onChange={(e) => setGender(e.target.value as Gender)}
+            >
+              {GENDER_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </Select>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="template_tier">Template Tier</Label>
+            <Input
+              id="template_tier"
+              value={TIER_LABELS[profile.template_tier]}
+              disabled
+              className="opacity-60"
+            />
+            <p className="text-xs text-content-muted">Template tier is set by your coach or admin</p>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Save Button */}
+      <div className="flex justify-end">
+        <Button onClick={handleSave} disabled={saving}>
+          {saving ? "Saving..." : "Save Changes"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -1,0 +1,32 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import SettingsForm from "./SettingsForm";
+
+export default async function SettingsPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect("/login");
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("id, full_name, email, role, gender, template_tier, coach_id")
+    .eq("id", user.id)
+    .single();
+
+  if (!profile) redirect("/login");
+
+  return (
+    <div>
+      <h1 className="text-xl sm:text-2xl font-bold text-content-primary font-display mb-1">
+        Settings
+      </h1>
+      <p className="text-sm text-content-secondary mb-6">
+        Manage your profile and preferences
+      </p>
+      <SettingsForm profile={profile} />
+    </div>
+  );
+}

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -1,0 +1,75 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+// GET /api/settings — returns current user's profile
+export async function GET() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { data: profile, error } = await supabase
+    .from("profiles")
+    .select("id, full_name, email, role, gender, template_tier, coach_id")
+    .eq("id", user.id)
+    .single();
+
+  if (error || !profile) {
+    console.error("[settings/GET]", error);
+    return NextResponse.json({ error: "Profile not found" }, { status: 404 });
+  }
+
+  return NextResponse.json(profile);
+}
+
+// PATCH /api/settings — updates allowed fields (full_name, gender)
+export async function PATCH(request: Request) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const body = await request.json();
+
+  // Only allow updating full_name and gender
+  const updates: Record<string, unknown> = {};
+
+  if (typeof body.full_name === "string") {
+    const trimmed = body.full_name.trim();
+    if (trimmed.length === 0) {
+      return NextResponse.json({ error: "Name cannot be empty" }, { status: 400 });
+    }
+    if (trimmed.length > 100) {
+      return NextResponse.json({ error: "Name is too long" }, { status: 400 });
+    }
+    updates.full_name = trimmed;
+  }
+
+  if (body.gender !== undefined) {
+    const validGenders = ["male", "female", "other", "unset"];
+    if (!validGenders.includes(body.gender)) {
+      return NextResponse.json({ error: "Invalid gender value" }, { status: 400 });
+    }
+    updates.gender = body.gender;
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return NextResponse.json({ error: "No valid fields to update" }, { status: 400 });
+  }
+
+  const { data: profile, error } = await supabase
+    .from("profiles")
+    .update(updates)
+    .eq("id", user.id)
+    .select("id, full_name, email, role, gender, template_tier, coach_id")
+    .single();
+
+  if (error) {
+    console.error("[settings/PATCH]", error);
+    return NextResponse.json({ error: "Failed to update profile" }, { status: 500 });
+  }
+
+  return NextResponse.json(profile);
+}

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -12,6 +12,7 @@ import {
   UserCog,
   ClipboardList,
   BarChart3,
+  Settings,
 } from "lucide-react";
 import { getNavItems, type NavItem } from "@/lib/profile";
 import type { UserRole } from "@/lib/types";
@@ -26,6 +27,7 @@ const ICON_MAP: Record<string, React.ElementType> = {
   UserCog,
   ClipboardList,
   BarChart3,
+  Settings,
 };
 
 interface SidebarProps {

--- a/lib/profile.ts
+++ b/lib/profile.ts
@@ -22,6 +22,8 @@ export function getNavItems(role: UserRole, hasCoach: boolean): NavItem[] {
     userItems.push({ label: "Coach's Notes", href: "/coach-notes", icon: "MessageSquare" });
   }
 
+  userItems.push({ label: "Settings", href: "/settings", icon: "Settings" });
+
   const coachItems: NavItem[] = [
     { label: "Clients", href: "/clients", icon: "Users" },
     { label: "Playbook", href: "/playbook", icon: "BookOpen" },

--- a/tests/profile.test.ts
+++ b/tests/profile.test.ts
@@ -20,6 +20,19 @@ describe("getNavItems — user role", () => {
     expect(items.map((i) => i.href)).toContain("/coach-notes");
   });
 
+  it("includes settings for all users", () => {
+    const items = getNavItems("user", false);
+    const hrefs = items.map((i) => i.href);
+    expect(hrefs).toContain("/settings");
+  });
+
+  it("places settings after other user items", () => {
+    const items = getNavItems("user", false);
+    const settingsIdx = items.findIndex((i) => i.href === "/settings");
+    const progressIdx = items.findIndex((i) => i.href === "/progress");
+    expect(settingsIdx).toBeGreaterThan(progressIdx);
+  });
+
   it("excludes coach and admin items", () => {
     const items = getNavItems("user", false);
     const hrefs = items.map((i) => i.href);
@@ -36,6 +49,11 @@ describe("getNavItems — coach role", () => {
     expect(hrefs).toContain("/dashboard");
     expect(hrefs).toContain("/clients");
     expect(hrefs).toContain("/playbook");
+  });
+
+  it("includes settings", () => {
+    const items = getNavItems("coach", false);
+    expect(items.map((i) => i.href)).toContain("/settings");
   });
 
   it("excludes admin items", () => {
@@ -55,6 +73,7 @@ describe("getNavItems — admin role", () => {
     expect(hrefs).toContain("/playbook");
     expect(hrefs).toContain("/admin/users");
     expect(hrefs).toContain("/admin/programs");
+    expect(hrefs).toContain("/settings");
   });
 });
 


### PR DESCRIPTION
## Summary
- **Settings page** — new `/settings` route with three card sections: Profile (editable name, read-only email/role), Preferences (theme radio group synced to localStorage), Account (gender select, read-only template tier)
- **API route** — GET/PATCH `/api/settings` with validation (full_name required, max 100 chars, valid gender values only). Blocks changes to role/email/template_tier/coach_id.
- **Navigation** — Settings item added to sidebar for all roles (user/coach/admin) with gear icon
- **3 new tests** — Settings nav item visibility across roles

## Test plan
- [ ] Settings appears in sidebar for all roles
- [ ] Profile name can be edited and saved
- [ ] Email and role display as read-only
- [ ] Theme preference radio group syncs with ThemeToggle
- [ ] Gender can be changed and saved
- [ ] Invalid inputs show appropriate errors
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm test` — 617 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)