### PR TITLE
feat: add workout data CSV export

### DIFF
--- a/app/(app)/sessions/history/ExportButton.tsx
+++ b/app/(app)/sessions/history/ExportButton.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useState } from "react";
+import { Download } from "lucide-react";
+import { toast } from "sonner";
+
+export function ExportButton() {
+  const [loading, setLoading] = useState(false);
+
+  async function handleExport() {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/sessions/export");
+      if (!res.ok) {
+        const msg = res.status === 404
+          ? "No completed sessions to export"
+          : "Failed to export data";
+        toast.error(msg);
+        return;
+      }
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download =
+        res.headers.get("Content-Disposition")?.match(/filename="(.+)"/)?.[1] ??
+        "buildbase-workouts.csv";
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+      toast.success("Workout data exported");
+    } catch {
+      toast.error("Export failed — please try again");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleExport}
+      disabled={loading}
+      className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg border border-border-subtle text-content-secondary hover:text-content-primary hover:border-border-strong transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+    >
+      <Download size={14} />
+      {loading ? "Exporting..." : "Export CSV"}
+    </button>
+  );
+}

--- a/app/(app)/sessions/history/page.tsx
+++ b/app/(app)/sessions/history/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 import Link from "next/link";
 import { ChevronLeft, ChevronRight, Calendar, Dumbbell, Clock } from "lucide-react";
 import { EFFORT_LABELS } from "@/lib/constants";
+import { ExportButton } from "./ExportButton";
 
 interface SearchParams {
   page?: string;
@@ -304,6 +305,7 @@ export default async function SessionHistoryPage({
             {total} completed {total === 1 ? "session" : "sessions"}
           </p>
         </div>
+        {total > 0 && <ExportButton />}
       </div>
 
       {/* Error state */}

--- a/app/api/sessions/export/route.ts
+++ b/app/api/sessions/export/route.ts
@@ -1,0 +1,120 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+export async function GET() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data: sessions, error: sessionsError } = await supabase
+    .from("session_logs")
+    .select(
+      `
+      id,
+      week_number,
+      session_number,
+      started_at,
+      completed_at,
+      is_complete,
+      post_session_effort,
+      pre_session_soreness,
+      notes,
+      workout_templates (
+        day_label,
+        title
+      )
+    `
+    )
+    .eq("user_id", user.id)
+    .eq("is_complete", true)
+    .order("completed_at", { ascending: false });
+
+  if (sessionsError) {
+    console.error("[sessions/export/GET] sessions error:", sessionsError);
+    return NextResponse.json(
+      { error: "Failed to export session data" },
+      { status: 500 }
+    );
+  }
+
+  if (!sessions || sessions.length === 0) {
+    return new Response("No completed sessions to export", { status: 404 });
+  }
+
+  const sessionIds = sessions.map((s) => s.id);
+
+  const { data: setLogs } = await supabase
+    .from("set_logs")
+    .select(
+      `
+      session_log_id,
+      set_number,
+      weight_used,
+      reps_completed,
+      exercises (
+        name
+      )
+    `
+    )
+    .in("session_log_id", sessionIds)
+    .eq("is_completed", true)
+    .order("set_number", { ascending: true });
+
+  const setLogsBySession: Record<string, NonNullable<typeof setLogs>> = {};
+  if (setLogs) {
+    for (const log of setLogs) {
+      if (!setLogsBySession[log.session_log_id]) {
+        setLogsBySession[log.session_log_id] = [];
+      }
+      setLogsBySession[log.session_log_id]!.push(log);
+    }
+  }
+
+  const rows: string[] = [
+    "Date,Week,Session,Day,Title,Exercise,Set,Weight (lbs),Reps,Effort,Soreness,Notes",
+  ];
+
+  for (const session of sessions) {
+    const date = session.completed_at
+      ? new Date(session.completed_at).toLocaleDateString("en-US")
+      : "";
+    const templateRaw = session.workout_templates as unknown;
+    const template = (Array.isArray(templateRaw) ? templateRaw[0] : templateRaw) as { day_label: string; title: string } | null;
+    const dayLabel = template?.day_label ?? "";
+    const title = template?.title ?? "";
+    const effort = session.post_session_effort ?? "";
+    const soreness = session.pre_session_soreness ?? "";
+    const notes = (session.notes ?? "").replace(/"/g, '""');
+
+    const sets = setLogsBySession[session.id];
+    if (sets && sets.length > 0) {
+      for (const set of sets) {
+        const exerciseRaw = set.exercises as unknown;
+        const exercise = (Array.isArray(exerciseRaw) ? exerciseRaw[0] : exerciseRaw) as { name: string } | null;
+        const exerciseName = exercise?.name ?? "Unknown";
+        rows.push(
+          `"${date}",${session.week_number},${session.session_number},"${dayLabel}","${title}","${exerciseName}",${set.set_number},${set.weight_used ?? ""},${set.reps_completed ?? ""},${effort},${soreness},"${notes}"`
+        );
+      }
+    } else {
+      rows.push(
+        `"${date}",${session.week_number},${session.session_number},"${dayLabel}","${title}",,,,${effort},${soreness},"${notes}"`
+      );
+    }
+  }
+
+  const csv = rows.join("\n");
+  const filename = `buildbase-workouts-${new Date().toISOString().slice(0, 10)}.csv`;
+
+  return new Response(csv, {
+    headers: {
+      "Content-Type": "text/csv",
+      "Content-Disposition": `attachment; filename="${filename}"`,
+    },
+  });
+}

--- a/tests/sessions-export.test.ts
+++ b/tests/sessions-export.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockGetUser = vi.fn();
+const mockSelect = vi.fn();
+const mockEq = vi.fn();
+const mockOrder = vi.fn();
+const mockIn = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() => ({
+    auth: { getUser: mockGetUser },
+    from: vi.fn(() => ({
+      select: mockSelect,
+    })),
+  })),
+}));
+
+function setupChain(data: unknown, error: unknown = null) {
+  mockSelect.mockReturnValue({
+    eq: vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        order: vi.fn().mockReturnValue({
+          data,
+          error,
+        }),
+      }),
+    }),
+    in: vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        order: vi.fn().mockReturnValue({
+          data: [],
+          error: null,
+        }),
+      }),
+    }),
+  });
+}
+
+describe("GET /api/sessions/export", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+
+    const { GET } = await import("@/app/api/sessions/export/route");
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when user has no completed sessions", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } } });
+    setupChain([]);
+
+    const { GET } = await import("@/app/api/sessions/export/route");
+    const res = await GET();
+    expect(res.status).toBe(404);
+  });
+
+  it("returns CSV with correct headers when sessions exist", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } } });
+
+    const sessions = [
+      {
+        id: "session-1",
+        week_number: 1,
+        session_number: 1,
+        started_at: "2026-01-01T10:00:00Z",
+        completed_at: "2026-01-01T11:00:00Z",
+        is_complete: true,
+        post_session_effort: 3,
+        pre_session_soreness: 2,
+        notes: null,
+        workout_templates: { day_label: "A", title: "Upper Body" },
+      },
+    ];
+
+    setupChain(sessions);
+
+    const { GET } = await import("@/app/api/sessions/export/route");
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("text/csv");
+    expect(res.headers.get("Content-Disposition")).toContain("attachment");
+    expect(res.headers.get("Content-Disposition")).toContain(".csv");
+
+    const body = await res.text();
+    const lines = body.split("\n");
+    expect(lines[0]).toBe(
+      "Date,Week,Session,Day,Title,Exercise,Set,Weight (lbs),Reps,Effort,Soreness,Notes"
+    );
+    expect(lines.length).toBeGreaterThan(1);
+  });
+});


### PR DESCRIPTION
## Summary
- New `GET /api/sessions/export` endpoint that generates a CSV of all completed workouts (date, exercise, sets, weight, reps, effort, soreness)
- Export button on the session history page (appears when user has completed sessions)
- Handles edge cases: no sessions (404), unauthenticated (401), exercises with no set data

## Test plan
- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm test` passes (630 tests)
- [x] New test file `tests/sessions-export.test.ts` covers auth, empty state, and CSV format
- [ ] Manual: log in, navigate to /sessions/history, click "Export CSV", verify downloaded file

🤖 Generated with [Claude Code](https://claude.com/claude-code)