### PR TITLE
feat: add rest timer between sets

### DIFF
--- a/app/(app)/sessions/RestTimer.tsx
+++ b/app/(app)/sessions/RestTimer.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { Timer, X, RotateCcw } from "lucide-react";
+
+const DEFAULT_REST_SECONDS = 90;
+const REST_OPTIONS = [60, 90, 120, 180];
+
+interface RestTimerProps {
+  onClose: () => void;
+}
+
+export default function RestTimer({ onClose }: RestTimerProps) {
+  const [duration, setDuration] = useState(DEFAULT_REST_SECONDS);
+  const [remaining, setRemaining] = useState(DEFAULT_REST_SECONDS);
+  const [isRunning, setIsRunning] = useState(true);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const clear = useCallback(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isRunning && remaining > 0) {
+      intervalRef.current = setInterval(() => {
+        setRemaining((r) => {
+          if (r <= 1) {
+            clear();
+            setIsRunning(false);
+            if (typeof navigator !== "undefined" && "vibrate" in navigator) {
+              navigator.vibrate([200, 100, 200]);
+            }
+            return 0;
+          }
+          return r - 1;
+        });
+      }, 1000);
+    }
+    return clear;
+  }, [isRunning, remaining, clear]);
+
+  const reset = () => {
+    clear();
+    setRemaining(duration);
+    setIsRunning(true);
+  };
+
+  const changeDuration = (secs: number) => {
+    clear();
+    setDuration(secs);
+    setRemaining(secs);
+    setIsRunning(true);
+  };
+
+  const minutes = Math.floor(remaining / 60);
+  const seconds = remaining % 60;
+  const progress = duration > 0 ? ((duration - remaining) / duration) * 100 : 100;
+  const isDone = remaining === 0;
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50 bg-bg-elevated border border-border-subtle rounded-xl shadow-lg p-4 w-64 animate-in slide-in-from-bottom-2">
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2 text-content-primary">
+          <Timer size={16} className={isDone ? "text-success" : "text-accent"} />
+          <span className="text-sm font-semibold">
+            {isDone ? "Rest Complete" : "Rest Timer"}
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="w-6 h-6 flex items-center justify-center rounded text-content-muted hover:text-content-primary hover:bg-bg-hover transition-colors"
+          aria-label="Close timer"
+        >
+          <X size={14} />
+        </button>
+      </div>
+
+      {/* Countdown */}
+      <div className="text-center mb-3">
+        <span className={`text-3xl font-bold font-mono tabular-nums ${isDone ? "text-success" : "text-content-primary"}`}>
+          {minutes}:{seconds.toString().padStart(2, "0")}
+        </span>
+      </div>
+
+      {/* Progress bar */}
+      <div className="h-1.5 rounded-full bg-bg-surface mb-3 overflow-hidden">
+        <div
+          className={`h-full rounded-full transition-all duration-1000 ease-linear ${isDone ? "bg-success" : "bg-accent"}`}
+          style={{ width: `${progress}%` }}
+        />
+      </div>
+
+      {/* Duration presets */}
+      <div className="flex gap-1.5 mb-3">
+        {REST_OPTIONS.map((secs) => (
+          <button
+            key={secs}
+            type="button"
+            onClick={() => changeDuration(secs)}
+            className={`flex-1 text-xs py-1 rounded-md border transition-colors ${
+              duration === secs
+                ? "border-accent text-accent bg-accent/10"
+                : "border-border-subtle text-content-secondary hover:border-border-strong"
+            }`}
+          >
+            {secs >= 60 ? `${secs / 60}m` : `${secs}s`}
+          </button>
+        ))}
+      </div>
+
+      {/* Reset */}
+      <button
+        type="button"
+        onClick={reset}
+        className="w-full flex items-center justify-center gap-1.5 text-xs py-1.5 rounded-md border border-border-subtle text-content-secondary hover:text-content-primary hover:border-border-strong transition-colors"
+      >
+        <RotateCcw size={12} />
+        Reset
+      </button>
+    </div>
+  );
+}

--- a/app/(app)/sessions/SessionCard.tsx
+++ b/app/(app)/sessions/SessionCard.tsx
@@ -9,6 +9,7 @@ import { ChevronDown, ChevronRight, Play, CheckCircle, Loader2, Video } from "lu
 import { apiFetchJson } from "@/lib/api-helpers";
 import { toast } from "sonner";
 import SetRow from "./SetRow";
+import RestTimer from "./RestTimer";
 import EffortPrompt from "./EffortPrompt";
 import SorenessPrompt from "./SorenessPrompt";
 import SessionDetailModal from "./SessionDetailModal";
@@ -48,6 +49,7 @@ export default function SessionCard({
   const [sorenessPrompted, setSorenessPrompted] = useState(session.soreness_prompted ?? false);
   const [showDetailModal, setShowDetailModal] = useState(false);
   const [showPreview, setShowPreview] = useState(false);
+  const [showRestTimer, setShowRestTimer] = useState(false);
 
   const isVirtual = session.id.startsWith("virtual-");
   const sessionLogId = realSessionId;
@@ -275,6 +277,7 @@ export default function SessionCard({
                               ? { setLogId: existing.id, weight: existing.weight_used, reps: existing.reps_completed }
                               : undefined
                           }
+                          onSetLogged={() => setShowRestTimer(true)}
                         />
                       );
                     })}
@@ -342,6 +345,10 @@ export default function SessionCard({
             userGender={userGender}
           />
         </CardContent>
+      )}
+
+      {showRestTimer && (
+        <RestTimer onClose={() => setShowRestTimer(false)} />
       )}
     </Card>
   );

--- a/app/(app)/sessions/SetRow.tsx
+++ b/app/(app)/sessions/SetRow.tsx
@@ -21,6 +21,7 @@ interface SetRowProps {
   tier: "pre_baseline" | "default" | "post_baseline";
   gender: "male" | "female" | "other" | "unset";
   existingLog?: LoggedSet;
+  onSetLogged?: () => void;
 }
 
 export default function SetRow({
@@ -30,6 +31,7 @@ export default function SetRow({
   tier,
   gender,
   existingLog,
+  onSetLogged,
 }: SetRowProps) {
   const defaultWeight = getDefaultWeight(templateExercise, tier, gender);
 
@@ -54,6 +56,7 @@ export default function SetRow({
         }),
       });
       setIsLogged(true);
+      onSetLogged?.();
     } catch {
       toast.error("Failed to log set");
     } finally {

--- a/tests/rest-timer.test.ts
+++ b/tests/rest-timer.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act, fireEvent } from "@testing-library/react";
+import React from "react";
+
+describe("RestTimer", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders with default 90s and counts down", async () => {
+    const RestTimer = (await import("@/app/(app)/sessions/RestTimer")).default;
+    const onClose = vi.fn();
+
+    render(React.createElement(RestTimer, { onClose }));
+
+    expect(screen.getByText("1:30")).toBeTruthy();
+
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+
+    expect(screen.getByText("1:20")).toBeTruthy();
+  });
+
+  it("shows 'Rest Complete' when timer reaches 0", async () => {
+    const RestTimer = (await import("@/app/(app)/sessions/RestTimer")).default;
+    const onClose = vi.fn();
+
+    render(React.createElement(RestTimer, { onClose }));
+
+    act(() => {
+      vi.advanceTimersByTime(90_000);
+    });
+
+    expect(screen.getByText("Rest Complete")).toBeTruthy();
+    expect(screen.getByText("0:00")).toBeTruthy();
+  });
+
+  it("calls onClose when X button is clicked", async () => {
+    const RestTimer = (await import("@/app/(app)/sessions/RestTimer")).default;
+    const onClose = vi.fn();
+
+    render(React.createElement(RestTimer, { onClose }));
+
+    const closeBtn = screen.getByLabelText("Close timer");
+    fireEvent.click(closeBtn);
+
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("resets timer when Reset button is clicked", async () => {
+    const RestTimer = (await import("@/app/(app)/sessions/RestTimer")).default;
+    const onClose = vi.fn();
+
+    render(React.createElement(RestTimer, { onClose }));
+
+    act(() => {
+      vi.advanceTimersByTime(30_000);
+    });
+
+    expect(screen.getByText("1:00")).toBeTruthy();
+
+    const resetBtn = screen.getByText("Reset");
+    fireEvent.click(resetBtn);
+
+    expect(screen.getByText("1:30")).toBeTruthy();
+  });
+
+  it("changes duration when a preset is clicked", async () => {
+    const RestTimer = (await import("@/app/(app)/sessions/RestTimer")).default;
+    const onClose = vi.fn();
+
+    render(React.createElement(RestTimer, { onClose }));
+
+    const twoMinBtn = screen.getByText("2m");
+    fireEvent.click(twoMinBtn);
+
+    expect(screen.getByText("2:00")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- New `RestTimer` component: floating countdown widget that auto-starts after logging a set
- Configurable duration presets (60s, 90s, 120s, 180s) — defaults to 90s
- Vibration alert when timer completes (mobile-friendly)
- Reset and close controls, progress bar visualization
- Wired into `SessionCard` via `onSetLogged` callback on `SetRow`

## Test plan
- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm test` passes (632 tests)
- [x] New test file `tests/rest-timer.test.ts` covers countdown, completion, reset, preset switching
- [ ] Manual: start a session, log a set, verify timer appears and counts down

🤖 Generated with [Claude Code](https://claude.com/claude-code)